### PR TITLE
Name changes and allowing failure before destroy

### DIFF
--- a/.github/workflows/basicterraformchecks.yml
+++ b/.github/workflows/basicterraformchecks.yml
@@ -1,4 +1,4 @@
-name: "Terraform"
+name: "Terraform init and fmt"
 
 on:
   push:

--- a/.github/workflows/deploytostagingenv.yml
+++ b/.github/workflows/deploytostagingenv.yml
@@ -1,8 +1,8 @@
-name: "Deploy staging branch to staging environment"
+name: "Deploy current branch to staging environment"
 
 on:
   schedule:
-    - cron: "0 */12 * * *" # This runs every 12 hours
+    - cron: "0 */12 * * *" # This runs every 12 hours but only from main
   #push: staging should only be PR'd into
   #  branches: ["staging"]
   pull_request:
@@ -43,6 +43,7 @@ jobs:
 
       # Runs Terraform using envionrment variables
       - name: Terraform Apply
+        continue-on-error: true #even if apply fails, we want to try destroy to clean-up
         run: |
           terraform apply -var "jamfpro_instance_url=${{ secrets.jamfpro_instance_url }}" \
                           -var "jamfpro_client_id=${{ secrets.jamfpro_client_id }}" \


### PR DESCRIPTION
If a Terraform Apply failed, the job would end and we'd be left with orphaned resources. This allows the job to continue and attempt Terraform Destroy. The action will still exit with status code 1 - and hence be failed/red