### PR TITLE
Changes to slow down terraform

### DIFF
--- a/.github/workflows/deploytostagingenv.yml
+++ b/.github/workflows/deploytostagingenv.yml
@@ -64,5 +64,5 @@ jobs:
                           -var "include_ej_base=true" \
                           -var "include_ej_jsc_config=true" \
                           -auto-approve \
-                          -parallelism=1
+                          -parallelism=1 \
                           -refresh=false


### PR DESCRIPTION
Issue saw in https://github.com/jamf/ExperienceJamf-Terraform/actions/runs/11220713011/job/31189471246


Terraform refreshes state on destroy but Jamf Pro API - decides to return null resources sometimes from old loadbalancer