### PR TITLE
Clear exit destroy code

### DIFF
--- a/.github/workflows/runallspecmodules.yml
+++ b/.github/workflows/runallspecmodules.yml
@@ -87,6 +87,7 @@ jobs:
             if [ "$exit_code_destroy" -ne 0 ]; then
               echo "destroy failed so waiting 120 seconds before trying again" #tomcats please sync
               sleep 121 
+              exit_code_destroy=0 #clear error code
               terraform destroy -auto-approve -var "$line" -var "jamfpro_instance_url=${{ secrets.jamfpro_instance_url }}" \
                           -var "jamfpro_client_id=${{ secrets.jamfpro_client_id }}" \
                           -var "jamfpro_client_secret=${{ secrets.jamfpro_client_secret }}" \


### PR DESCRIPTION
# Change

If we are forced to wait 120 seconds on destroy (tomcat issues), clear the exit code so we don't always wait on futher destroys.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I have updated spec.yaml as appropriate
- [ ] I have checked `Terraform Init` and `Terraform Fmt`
- [ ] I have ran `Terraform Apply` against any active module changes
