### PR TITLE
mobile device smart groups added to pro smart group module

### DIFF
--- a/modules/onboarder_modules/jamf_pro_trial_kickstart/qol_smart_groups/main.tf
+++ b/modules/onboarder_modules/jamf_pro_trial_kickstart/qol_smart_groups/main.tf
@@ -63,3 +63,58 @@ resource "jamfpro_smart_computer_group" "group_available_swu" {
     priority    = 0
   }
 }
+
+resource "jamfpro_smart_mobile_device_group" "supervised_ios" {
+  name = "Supervised Devices"
+
+  criteria {
+    name        = "Supervised"
+    priority    = 0
+    search_type = "is"
+    value       = "Supervised"
+  }
+}
+
+resource "jamfpro_smart_mobile_device_group" "unsupervised_ios" {
+  name = "Un-Supervised Devices"
+
+  criteria {
+    name        = "Supervised"
+    priority    = 0
+    search_type = "is"
+    value       = "Unsupervised"
+  }
+}
+
+resource "jamfpro_smart_mobile_device_group" "byod_ios" {
+  name = "BYOD Devices"
+
+  criteria {
+    name        = "Serial Number"
+    priority    = 0
+    search_type = "like"
+    value       = ""
+  }
+}
+
+resource "jamfpro_smart_mobile_device_group" "ios_17" {
+  name = "Devices Running iOS 17"
+
+  criteria {
+    name        = "OS Version"
+    priority    = 0
+    search_type = "like"
+    value       = "17."
+  }
+}
+
+resource "jamfpro_smart_mobile_device_group" "ios_18" {
+  name = "Devices Running iOS 18"
+
+  criteria {
+    name        = "OS Version"
+    priority    = 0
+    search_type = "like"
+    value       = "18."
+  }
+}


### PR DESCRIPTION
# Mobile Smart Groups added to qol_smart_groups module

**_State your intended change to Experience Jamf_**

Added mobile smart groups to `qol_smart_groups` module

- Supervised iOS / iPadOS
- Unsupervised iOS / iPadOS
- BYOD iOS / iPadOS
- Devices running iOS 17
- Devices running iOS 18

## Type of Change

- [X] New feature (non-breaking change which adds functionality)

## Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (readme)
- [X] I have updated spec.yaml as appropraite
- [X] I have checked `Terraform Init` and `Terraform Fmt`
- [X] I have ran `Terraform Apply` against any active module changes
