### PR TITLE
Hotfix - Resolving Duplicated Smart Groups in Separate Profiles

### DIFF
--- a/modules/onboarder_modules/jamf_pro_trial_kickstart/qol_smart_groups/main.tf
+++ b/modules/onboarder_modules/jamf_pro_trial_kickstart/qol_smart_groups/main.tf
@@ -42,16 +42,16 @@ resource "jamfpro_smart_computer_group" "group_last_checkin" {
   }
 }
 
-resource "jamfpro_smart_computer_group" "group_disk_encrypted" {
-  name = "* FileVault 2 Enabled"
-  criteria {
-    name        = "FileVault 2 Partition Encryption State"
-    search_type = "is"
-    value       = "Encrypted"
-    and_or      = "and"
-    priority    = 0
-  }
-}
+# resource "jamfpro_smart_computer_group" "group_disk_encrypted" {
+#   name = "* FileVault 2 Enabled"
+#   criteria {
+#     name        = "FileVault 2 Partition Encryption State"
+#     search_type = "is"
+#     value       = "Encrypted"
+#     and_or      = "and"
+#     priority    = 0
+#   }
+# }
 
 resource "jamfpro_smart_computer_group" "group_available_swu" {
   name = "* Available Software Updates"


### PR DESCRIPTION
**_State your intended change to Experience Jamf_**

There was a run in occurring where a Smart Computer Group was attempting to create in 2 separate modules. This has now been resolved. The * FileVault 2 Enabled Smart Computer Group is now only created in the FileVault 2 Outcome module.

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Release to main from staging branch

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I have updated spec.yaml as appropraite
- [x] I have checked `Terraform Init` and `Terraform Fmt`
- [x] I have ran `Terraform Apply` against any active module changes
