### PR TITLE
changes to mobile kickstart to pass new name to smart groups 

### DIFF
--- a/modules/onboarder_modules/jamf_pro_trial_kickstart/mobile_device_kickstart/main.tf
+++ b/modules/onboarder_modules/jamf_pro_trial_kickstart/mobile_device_kickstart/main.tf
@@ -139,7 +139,7 @@ resource "jamfpro_smart_mobile_device_group" "device_type_kiosk_mode" {
   name = "Demo - Kiosk Devices [${random_id.entropy.hex}]"
 
   criteria {
-    name        = "Device Type"
+    name        = jamfpro_mobile_device_extension_attribute.device_type.name
     priority    = 0
     search_type = "is"
     value       = "Kiosk Device"
@@ -150,7 +150,7 @@ resource "jamfpro_smart_mobile_device_group" "device_type_shared_device_mode" {
   name = "Demo - Shared Devices [${random_id.entropy.hex}]"
 
   criteria {
-    name        = "Device Type"
+    name        = jamfpro_mobile_device_extension_attribute.device_type.name
     priority    = 0
     search_type = "is"
     value       = "Shared Device"


### PR DESCRIPTION
# Change

**_State your intended change to Experience Jamf_**

This changes the smart mobile device group logic to support variable naming. This is necessary for the random number generator that we added recently.

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I have updated spec.yaml as appropraite
- [x] I have checked `Terraform Init` and `Terraform Fmt`
- [x] I have ran `Terraform Apply` against any active module changes
