### PR TITLE
updated messaging on smart card config profiles

### DIFF
--- a/modules/trusted_access_outcomes/endpoint_compliance/computers/mac_800_171_benchmark/main.tf
+++ b/modules/trusted_access_outcomes/endpoint_compliance/computers/mac_800_171_benchmark/main.tf
@@ -321,7 +321,6 @@ locals {
     "Screen Saver"          = "${var.support_files_path_prefix}modules/trusted_access_outcomes/endpoint_compliance/computers/mac_800_171_benchmark/support_files/computer_config_profiles/Sonoma_800-171-screensaver.mobileconfig"
     "Firewall"              = "${var.support_files_path_prefix}modules/trusted_access_outcomes/endpoint_compliance/computers/mac_800_171_benchmark/support_files/computer_config_profiles/Sonoma_800-171-security.firewall.mobileconfig"
     "Security"              = "${var.support_files_path_prefix}modules/trusted_access_outcomes/endpoint_compliance/computers/mac_800_171_benchmark/support_files/computer_config_profiles/Sonoma_800-171-security.mobileconfig"
-    "Smart Card"            = "${var.support_files_path_prefix}modules/trusted_access_outcomes/endpoint_compliance/computers/mac_800_171_benchmark/support_files/computer_config_profiles/Sonoma_800-171-security.smartcard.mobileconfig"
     "Setup Assistant"       = "${var.support_files_path_prefix}modules/trusted_access_outcomes/endpoint_compliance/computers/mac_800_171_benchmark/support_files/computer_config_profiles/Sonoma_800-171-SetupAssistant.managed.mobileconfig"
     "Submit Diag Info"      = "${var.support_files_path_prefix}modules/trusted_access_outcomes/endpoint_compliance/computers/mac_800_171_benchmark/support_files/computer_config_profiles/Sonoma_800-171-SubmitDiagInfo.mobileconfig"
     "System Policy Control" = "${var.support_files_path_prefix}modules/trusted_access_outcomes/endpoint_compliance/computers/mac_800_171_benchmark/support_files/computer_config_profiles/Sonoma_800-171-systempolicy.control.mobileconfig"
@@ -349,6 +348,22 @@ resource "jamfpro_macos_configuration_profile_plist" "sonoma_800_171" {
   }
 }
 
+resource "jamfpro_macos_configuration_profile_plist" "sonoma_800_171_smart_card" {
+  name                = "Sonoma NIST 800-171 - Smart Card [${random_id.entropy.hex}]"
+  distribution_method = "Install Automatically"
+  redeploy_on_update  = "Newly Assigned"
+  category_id         = jamfpro_category.category_sonoma_800_171_benchmarks.id
+  level               = "System"
+
+  payloads         = file("${var.support_files_path_prefix}modules/trusted_access_outcomes/endpoint_compliance/computers/mac_800_171_benchmark/support_files/computer_config_profiles/Sonoma_800-171-security.smartcard.mobileconfig")
+  payload_validate = false
+
+  scope {
+    all_computers      = false
+    computer_group_ids = []
+  }
+}
+
 ## Define configuration profile details for Sequoia part 1
 locals {
   sequoia_800_171_dict = {
@@ -368,7 +383,6 @@ locals {
     "Password Policy"       = "${var.support_files_path_prefix}modules/trusted_access_outcomes/endpoint_compliance/computers/mac_800_171_benchmark/support_files/computer_config_profiles/Sequoia_800-171-mobiledevice.passwordpolicy.mobileconfig"
     "Screen Saver"          = "${var.support_files_path_prefix}modules/trusted_access_outcomes/endpoint_compliance/computers/mac_800_171_benchmark/support_files/computer_config_profiles/Sequoia_800-171-screensaver.mobileconfig"
     "Firewall"              = "${var.support_files_path_prefix}modules/trusted_access_outcomes/endpoint_compliance/computers/mac_800_171_benchmark/support_files/computer_config_profiles/Sequoia_800-171-security.firewall.mobileconfig"
-    "Smart Card"            = "${var.support_files_path_prefix}modules/trusted_access_outcomes/endpoint_compliance/computers/mac_800_171_benchmark/support_files/computer_config_profiles/Sequoia_800-171-security.smartcard.mobileconfig"
     "Setup Assistant"       = "${var.support_files_path_prefix}modules/trusted_access_outcomes/endpoint_compliance/computers/mac_800_171_benchmark/support_files/computer_config_profiles/Sequoia_800-171-SetupAssistant.managed.mobileconfig"
     "Submit Diag Info"      = "${var.support_files_path_prefix}modules/trusted_access_outcomes/endpoint_compliance/computers/mac_800_171_benchmark/support_files/computer_config_profiles/Sequoia_800-171-SubmitDiagInfo.mobileconfig"
     "System Policy Control" = "${var.support_files_path_prefix}modules/trusted_access_outcomes/endpoint_compliance/computers/mac_800_171_benchmark/support_files/computer_config_profiles/Sequoia_800-171-systempolicy.control.mobileconfig"
@@ -395,4 +409,20 @@ resource "jamfpro_macos_configuration_profile_plist" "sequoia_800_171" {
     computer_group_ids = [jamfpro_smart_computer_group.group_sequoia_computers.id]
   }
   depends_on = [jamfpro_macos_configuration_profile_plist.sonoma_800_171]
+}
+
+resource "jamfpro_macos_configuration_profile_plist" "sequoia_800_171_smart_card" {
+  name                = "Sequoia NIST 800-171 - Smart Card [${random_id.entropy.hex}]"
+  distribution_method = "Install Automatically"
+  redeploy_on_update  = "Newly Assigned"
+  category_id         = jamfpro_category.category_sequoia_800_171_benchmarks.id
+  level               = "System"
+
+  payloads         = file("${var.support_files_path_prefix}modules/trusted_access_outcomes/endpoint_compliance/computers/mac_800_171_benchmark/support_files/computer_config_profiles/Sequoia_800-171-security.smartcard.mobileconfig")
+  payload_validate = false
+
+  scope {
+    all_computers      = false
+    computer_group_ids = []
+  }
 }

--- a/modules/trusted_access_outcomes/endpoint_compliance/computers/mac_stig_benchmark/main.tf
+++ b/modules/trusted_access_outcomes/endpoint_compliance/computers/mac_stig_benchmark/main.tf
@@ -318,7 +318,6 @@ locals {
     "Sharing Preferences"           = "${var.support_files_path_prefix}modules/trusted_access_outcomes/endpoint_compliance/computers/mac_stig_benchmark/support_files/computer_config_profiles/Sonoma_stig-preferences.sharing.SharingPrefsExtension.mobileconfig"
     "Screen Saver"                  = "${var.support_files_path_prefix}modules/trusted_access_outcomes/endpoint_compliance/computers/mac_stig_benchmark/support_files/computer_config_profiles/Sonoma_stig-screensaver.mobileconfig"
     "Firewall"                      = "${var.support_files_path_prefix}modules/trusted_access_outcomes/endpoint_compliance/computers/mac_stig_benchmark/support_files/computer_config_profiles/Sonoma_stig-security.firewall.mobileconfig"
-    "Smart Card"                    = "${var.support_files_path_prefix}modules/trusted_access_outcomes/endpoint_compliance/computers/mac_stig_benchmark/support_files/computer_config_profiles/Sonoma_stig-security.smartcard.mobileconfig"
     "Setup Assistant"               = "${var.support_files_path_prefix}modules/trusted_access_outcomes/endpoint_compliance/computers/mac_stig_benchmark/support_files/computer_config_profiles/Sonoma_stig-SetupAssistant.managed.mobileconfig"
     "Software Update"               = "${var.support_files_path_prefix}modules/trusted_access_outcomes/endpoint_compliance/computers/mac_stig_benchmark/support_files/computer_config_profiles/Sonoma_stig-SoftwareUpdate.mobileconfig"
     "Submit Diag Info"              = "${var.support_files_path_prefix}modules/trusted_access_outcomes/endpoint_compliance/computers/mac_stig_benchmark/support_files/computer_config_profiles/Sonoma_stig-SubmitDiagInfo.mobileconfig"
@@ -346,6 +345,22 @@ resource "jamfpro_macos_configuration_profile_plist" "sonoma_stig" {
   }
 }
 
+resource "jamfpro_macos_configuration_profile_plist" "sonoma_stig_smart_card" {
+  name                = "Sonoma DISA STIG - Smart Card [${random_id.entropy.hex}]"
+  distribution_method = "Install Automatically"
+  redeploy_on_update  = "Newly Assigned"
+  category_id         = jamfpro_category.category_sonoma_stig_benchmarks.id
+  level               = "System"
+
+  payloads         = file("${var.support_files_path_prefix}modules/trusted_access_outcomes/endpoint_compliance/computers/mac_stig_benchmark/support_files/computer_config_profiles/Sonoma_stig-security.smartcard.mobileconfig")
+  payload_validate = false
+
+  scope {
+    all_computers      = false
+    computer_group_ids = []
+  }
+}
+
 ## Define configuration profile details for Sequoia part 1
 locals {
   sequoia_stig_dict = {
@@ -362,7 +377,6 @@ locals {
     "Password Policy"               = "${var.support_files_path_prefix}modules/trusted_access_outcomes/endpoint_compliance/computers/mac_stig_benchmark/support_files/computer_config_profiles/Sequoia_stig-mobiledevice.passwordpolicy.mobileconfig"
     "Screen Saver"                  = "${var.support_files_path_prefix}modules/trusted_access_outcomes/endpoint_compliance/computers/mac_stig_benchmark/support_files/computer_config_profiles/Sequoia_stig-screensaver.mobileconfig"
     "Firewall"                      = "${var.support_files_path_prefix}modules/trusted_access_outcomes/endpoint_compliance/computers/mac_stig_benchmark/support_files/computer_config_profiles/Sequoia_stig-security.firewall.mobileconfig"
-    "Smart Card"                    = "${var.support_files_path_prefix}modules/trusted_access_outcomes/endpoint_compliance/computers/mac_stig_benchmark/support_files/computer_config_profiles/Sequoia_stig-security.smartcard.mobileconfig"
     "Setup Assistant"               = "${var.support_files_path_prefix}modules/trusted_access_outcomes/endpoint_compliance/computers/mac_stig_benchmark/support_files/computer_config_profiles/Sequoia_stig-SetupAssistant.managed.mobileconfig"
     "Software Update"               = "${var.support_files_path_prefix}modules/trusted_access_outcomes/endpoint_compliance/computers/mac_stig_benchmark/support_files/computer_config_profiles/Sequoia_stig-SoftwareUpdate.mobileconfig"
     "Submit Diag Info"              = "${var.support_files_path_prefix}modules/trusted_access_outcomes/endpoint_compliance/computers/mac_stig_benchmark/support_files/computer_config_profiles/Sequoia_stig-SubmitDiagInfo.mobileconfig"
@@ -389,4 +403,20 @@ resource "jamfpro_macos_configuration_profile_plist" "sequoia_stig" {
     computer_group_ids = [jamfpro_smart_computer_group.group_sequoia_computers.id]
   }
   depends_on = [jamfpro_macos_configuration_profile_plist.sonoma_stig]
+}
+
+resource "jamfpro_macos_configuration_profile_plist" "sequoia_stig_smart_card" {
+  name                = "Sequoia DISA STIG - Smart Card [${random_id.entropy.hex}]"
+  distribution_method = "Install Automatically"
+  redeploy_on_update  = "Newly Assigned"
+  category_id         = jamfpro_category.category_sequoia_stig_benchmarks.id
+  level               = "System"
+
+  payloads         = file("${var.support_files_path_prefix}modules/trusted_access_outcomes/endpoint_compliance/computers/mac_stig_benchmark/support_files/computer_config_profiles/Sequoia_stig-security.smartcard.mobileconfig")
+  payload_validate = false
+
+  scope {
+    all_computers      = false
+    computer_group_ids = []
+  }
 }

--- a/spec.yml
+++ b/spec.yml
@@ -128,7 +128,7 @@ options:
     presence: optional
     category: Endpoint Compliance
     display_name: Configure and Apply DISA STIG for macOS
-    display_desc: CAUTION -  DISA STIG includes Smart Card configurations which can drastically alter login workflows on computers. This will create all the pieces required for you to apply DISA STIG to both macOS Sonoma and Sequoia. The Smart Groups that the Policies and Configuration Profiles are scoped to are built intentionally so they don't deploy automatically. To get DISA STIG enforcement, auditing, and remediation - you must edit the Smart Group created. You can either remove the Serial Number criteria to apply to all enrolled Macs or change the Serial Number criteria with your own test machine Serial Number to apply to one at a time. 
+    display_desc: CAUTION -  DISA STIG includes Smart Card configurations which can drastically alter login workflows on computers. The Profile will be created and uploaded to your Jamf Pro instance but it will NOT be scoped for this reason. This will create all the pieces required for you to apply DISA STIG to both macOS Sonoma and Sequoia. The Smart Groups that the Policies and Configuration Profiles are scoped to are built intentionally so they don't deploy automatically. To get DISA STIG enforcement, auditing, and remediation - you must edit the Smart Group created. You can either remove the Serial Number criteria to apply to all enrolled Macs or change the Serial Number criteria with your own test machine Serial Number to apply to one at a time. 
  
   - key: include_mobile_stig_benchmark
     type: <boolean>
@@ -142,7 +142,7 @@ options:
     presence: optional
     category: Endpoint Compliance
     display_name: Configure and Apply NIST 800-171 for macOS
-    display_desc: CAUTION -  the NIST 800-171 benchmark includes Smart Card configurations which can drastically alter login workflows on computers. This will create all the pieces required for you to apply NIST 800-171 to both macOS Sonoma and Sequoia. The Smart Groups that the Policies and Configuration Profiles are scoped to are built intentionally so they don't deploy automatically. To get NIST 800-171 enforcement, auditing, and remediation - you must edit the Smart Group created. You can either remove the Serial Number criteria to apply to all enrolled Macs or change the Serial Number criteria with your own test machine Serial Number to apply to one at a time. 
+    display_desc: CAUTION -  the NIST 800-171 benchmark includes Smart Card configurations which can drastically alter login workflows on computers. The Profile will be created and uploaded to your Jamf Pro instance but it will NOT be scoped for this reason. This will create all the pieces required for you to apply NIST 800-171 to both macOS Sonoma and Sequoia. The Smart Groups that the Policies and Configuration Profiles are scoped to are built intentionally so they don't deploy automatically. To get NIST 800-171 enforcement, auditing, and remediation - you must edit the Smart Group created. You can either remove the Serial Number criteria to apply to all enrolled Macs or change the Serial Number criteria with your own test machine Serial Number to apply to one at a time. 
   
   ## Jamf Security Cloud Onboarder Modules
   - key: include_jsc_uemc


### PR DESCRIPTION
Update to previous DISA STIG and NIST 800-171 modules - Smart Card configuration profiles are no longer scoped at all - new messaging added to spec.yml to reflect this. All other profiles and policies are still scoped to a Smart Group that can be easily adjusted to make deployment of the benchmarks simple.