### PR TITLE
Add copyright line to all .tf files

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Root provider requirements
 terraform {
   required_providers {

--- a/modules/experience_jamf_vignettes/ej_base/main.tf
+++ b/modules/experience_jamf_vignettes/ej_base/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 /*
 This terraform blueprint will build the Experience Jamf base config.
 It will do the following:

--- a/modules/experience_jamf_vignettes/ej_incident_response/main.tf
+++ b/modules/experience_jamf_vignettes/ej_incident_response/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 /*
 This terraform blueprint will build the Aftermath vignette from Experience Jamf.
 It will do the following:

--- a/modules/experience_jamf_vignettes/ej_incident_response/variables.tf
+++ b/modules/experience_jamf_vignettes/ej_incident_response/variables.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Define miscellaneous variables
 variable "prefix" {
   type    = string

--- a/modules/experience_jamf_vignettes/ej_jsc_config/main.tf
+++ b/modules/experience_jamf_vignettes/ej_jsc_config/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Call Terraform provider
 terraform {
   required_providers {

--- a/modules/experience_jamf_vignettes/ej_jsc_config/variables.tf
+++ b/modules/experience_jamf_vignettes/ej_jsc_config/variables.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 variable "jamfpro_instance_url" {
   type      = string
   sensitive = true

--- a/modules/experience_jamf_vignettes/ej_mac_LMAM/main.tf
+++ b/modules/experience_jamf_vignettes/ej_mac_LMAM/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 /*
 This terraform blueprint will build the Local macOS Accoiunt Management (LMAM) vignette as exists in Experience Jamf.
 

--- a/modules/experience_jamf_vignettes/ej_mac_LMAM/variables.tf
+++ b/modules/experience_jamf_vignettes/ej_mac_LMAM/variables.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Define miscellaneous variables
 variable "prefix" {
   type    = string

--- a/modules/experience_jamf_vignettes/ej_mac_cis_benchmark/main.tf
+++ b/modules/experience_jamf_vignettes/ej_mac_cis_benchmark/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 /*
 This terraform blueprint will build the macOS CIS Benchmark vignette from Experience Jamf.
 It will do the following:

--- a/modules/experience_jamf_vignettes/ej_mac_cis_benchmark/variables.tf
+++ b/modules/experience_jamf_vignettes/ej_mac_cis_benchmark/variables.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Define miscellaneous variables
 variable "prefix" {
   type    = string

--- a/modules/experience_jamf_vignettes/ej_mobile_cis_benchmark/main.tf
+++ b/modules/experience_jamf_vignettes/ej_mobile_cis_benchmark/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 /*
 This terraform blueprint will build the Mobile CIS Benchmark vignette from Experience Jamf.
 It will do the following:

--- a/modules/experience_jamf_vignettes/ej_saas_tenancy/jamf_saastenancy_cloud_formation_template.tf
+++ b/modules/experience_jamf_vignettes/ej_saas_tenancy/jamf_saastenancy_cloud_formation_template.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 
 
 data "aws_vpc" "default" {

--- a/modules/experience_jamf_vignettes/ej_saas_tenancy/jscconfig.tf
+++ b/modules/experience_jamf_vignettes/ej_saas_tenancy/jscconfig.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 resource "jsc_hostnamemapping" "saastenancy" {
   for_each  = toset(local.domain_array)
   hostname  = each.value

--- a/modules/experience_jamf_vignettes/ej_saas_tenancy/main.tf
+++ b/modules/experience_jamf_vignettes/ej_saas_tenancy/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 /*
 This terraform blueprint will build the SaaS Tenancy Control vignette from Experience Jamf.
 To do  -

--- a/modules/experience_jamf_vignettes/ej_saas_tenancy/prosaasconfig.tf
+++ b/modules/experience_jamf_vignettes/ej_saas_tenancy/prosaasconfig.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 data "http" "profile" {
   url = "http://${aws_eip.ElasticIP.public_ip}/download"
 

--- a/modules/experience_jamf_vignettes/ej_saas_tenancy/variables.tf
+++ b/modules/experience_jamf_vignettes/ej_saas_tenancy/variables.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Define miscellaneous variables
 variable "prefix" {
   type    = string

--- a/modules/onboarder_modules/app_installers/dropbox/main.tf
+++ b/modules/onboarder_modules/app_installers/dropbox/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Call Terraform provider
 terraform {
   required_providers {

--- a/modules/onboarder_modules/app_installers/google_chrome/main.tf
+++ b/modules/onboarder_modules/app_installers/google_chrome/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Call Terraform provider
 terraform {
   required_providers {

--- a/modules/onboarder_modules/app_installers/google_drive/main.tf
+++ b/modules/onboarder_modules/app_installers/google_drive/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Call Terraform provider
 terraform {
   required_providers {

--- a/modules/onboarder_modules/app_installers/jamf_composer/main.tf
+++ b/modules/onboarder_modules/app_installers/jamf_composer/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Call Terraform provider
 terraform {
   required_providers {

--- a/modules/onboarder_modules/app_installers/jamfcheck/main.tf
+++ b/modules/onboarder_modules/app_installers/jamfcheck/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Call Terraform provider
 terraform {
   required_providers {

--- a/modules/onboarder_modules/app_installers/mozilla_firefox/main.tf
+++ b/modules/onboarder_modules/app_installers/mozilla_firefox/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Call Terraform provider
 terraform {
   required_providers {

--- a/modules/onboarder_modules/app_installers/pppc_utility/main.tf
+++ b/modules/onboarder_modules/app_installers/pppc_utility/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Call Terraform provider
 terraform {
   required_providers {

--- a/modules/onboarder_modules/app_installers/slack/main.tf
+++ b/modules/onboarder_modules/app_installers/slack/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Call Terraform provider
 terraform {
   required_providers {

--- a/modules/onboarder_modules/app_installers/zoom/main.tf
+++ b/modules/onboarder_modules/app_installers/zoom/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Call Terraform provider
 terraform {
   required_providers {

--- a/modules/onboarder_modules/jamf_pro_trial_kickstart/categories/main.tf
+++ b/modules/onboarder_modules/jamf_pro_trial_kickstart/categories/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Call Terraform provider
 terraform {
   required_providers {

--- a/modules/onboarder_modules/jamf_pro_trial_kickstart/computer_management_settings/main.tf
+++ b/modules/onboarder_modules/jamf_pro_trial_kickstart/computer_management_settings/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Call Terraform provider
 terraform {
   required_providers {

--- a/modules/onboarder_modules/jamf_pro_trial_kickstart/computer_outcomes/crowdstrike/main.tf
+++ b/modules/onboarder_modules/jamf_pro_trial_kickstart/computer_outcomes/crowdstrike/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Call Terraform provider
 terraform {
   required_providers {

--- a/modules/onboarder_modules/jamf_pro_trial_kickstart/computer_outcomes/crowdstrike/variables.tf
+++ b/modules/onboarder_modules/jamf_pro_trial_kickstart/computer_outcomes/crowdstrike/variables.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Define miscellaneous variables
 variable "prefix" {
   type    = string

--- a/modules/onboarder_modules/jamf_pro_trial_kickstart/computer_outcomes/filevault/main.tf
+++ b/modules/onboarder_modules/jamf_pro_trial_kickstart/computer_outcomes/filevault/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Call Terraform provider
 terraform {
   required_providers {

--- a/modules/onboarder_modules/jamf_pro_trial_kickstart/computer_outcomes/filevault/variables.tf
+++ b/modules/onboarder_modules/jamf_pro_trial_kickstart/computer_outcomes/filevault/variables.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Define miscellaneous variables
 variable "prefix" {
   type    = string

--- a/modules/onboarder_modules/jamf_pro_trial_kickstart/computer_outcomes/microsoft_365/main.tf
+++ b/modules/onboarder_modules/jamf_pro_trial_kickstart/computer_outcomes/microsoft_365/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Call Terraform provider
 terraform {
   required_providers {

--- a/modules/onboarder_modules/jamf_pro_trial_kickstart/computer_outcomes/msft_defender/main.tf
+++ b/modules/onboarder_modules/jamf_pro_trial_kickstart/computer_outcomes/msft_defender/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Call Terraform provider
 terraform {
   required_providers {

--- a/modules/onboarder_modules/jamf_pro_trial_kickstart/computer_outcomes/msft_defender/variables.tf
+++ b/modules/onboarder_modules/jamf_pro_trial_kickstart/computer_outcomes/msft_defender/variables.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Define miscellaneous variables
 variable "prefix" {
   type    = string

--- a/modules/onboarder_modules/jamf_pro_trial_kickstart/computer_outcomes/rosetta/main.tf
+++ b/modules/onboarder_modules/jamf_pro_trial_kickstart/computer_outcomes/rosetta/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Call Terraform provider
 terraform {
   required_providers {

--- a/modules/onboarder_modules/jamf_pro_trial_kickstart/mobile_device_kickstart/main.tf
+++ b/modules/onboarder_modules/jamf_pro_trial_kickstart/mobile_device_kickstart/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 /*
 Trial Baseline For Mobile Devices
   Passcode requirements

--- a/modules/onboarder_modules/jamf_pro_trial_kickstart/mobile_device_kickstart/variables.tf
+++ b/modules/onboarder_modules/jamf_pro_trial_kickstart/mobile_device_kickstart/variables.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Define miscellaneous variables
 variable "prefix" {
   type    = string

--- a/modules/onboarder_modules/jamf_pro_trial_kickstart/qol_smart_groups/main.tf
+++ b/modules/onboarder_modules/jamf_pro_trial_kickstart/qol_smart_groups/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Call Terraform provider
 terraform {
   required_providers {

--- a/modules/onboarder_modules/jamf_protect_trial_kickstart/main.tf
+++ b/modules/onboarder_modules/jamf_protect_trial_kickstart/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Call Terraform provider
 terraform {
   required_providers {

--- a/modules/onboarder_modules/jamf_protect_trial_kickstart/variables.tf
+++ b/modules/onboarder_modules/jamf_protect_trial_kickstart/variables.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 variable "jamfpro_instance_url" {
   description = "Jamf Pro URL name."
   type        = string

--- a/modules/onboarder_modules/jamf_security_cloud_trial_kickstart/jsc_all_services/main.tf
+++ b/modules/onboarder_modules/jamf_security_cloud_trial_kickstart/jsc_all_services/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Call Terraform provider
 terraform {
   required_providers {

--- a/modules/onboarder_modules/jamf_security_cloud_trial_kickstart/jsc_all_services/variables.tf
+++ b/modules/onboarder_modules/jamf_security_cloud_trial_kickstart/jsc_all_services/variables.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 variable "jamfpro_instance_url" {
   type      = string
   sensitive = true

--- a/modules/onboarder_modules/jamf_security_cloud_trial_kickstart/jsc_block_pages/main.tf
+++ b/modules/onboarder_modules/jamf_security_cloud_trial_kickstart/jsc_block_pages/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Call Terraform provider
 terraform {
   required_providers {

--- a/modules/onboarder_modules/jamf_security_cloud_trial_kickstart/jsc_block_pages/variables.tf
+++ b/modules/onboarder_modules/jamf_security_cloud_trial_kickstart/jsc_block_pages/variables.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 variable "block_page_logo" {
   type      = string
   sensitive = false

--- a/modules/onboarder_modules/jamf_security_cloud_trial_kickstart/jsc_uemc/main.tf
+++ b/modules/onboarder_modules/jamf_security_cloud_trial_kickstart/jsc_uemc/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Call Terraform provider
 terraform {
   required_providers {

--- a/modules/onboarder_modules/jamf_security_cloud_trial_kickstart/jsc_uemc/variables.tf
+++ b/modules/onboarder_modules/jamf_security_cloud_trial_kickstart/jsc_uemc/variables.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 variable "jamfpro_instance_url" {
   type      = string
   sensitive = true

--- a/modules/reference_modules_unused/demo_sites.tf
+++ b/modules/reference_modules_unused/demo_sites.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 resource "jamfpro_site" "site_production" {
   name = "Production"
 }

--- a/modules/reference_modules_unused/jamfpro_prerequisites/main.tf
+++ b/modules/reference_modules_unused/jamfpro_prerequisites/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 /*
 This terraform module will install any required prerequisites for Experience Jamf vignettes.
 In main.tf will do the following:

--- a/modules/reference_modules_unused/jamfpro_prerequisites/tool_dialog.tf
+++ b/modules/reference_modules_unused/jamfpro_prerequisites/tool_dialog.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 /*
 This terraform blueprint will install the Dialog tool as part of its prerequisites.
 It will do the following:

--- a/modules/reference_modules_unused/jamfpro_prerequisites/variables.tf
+++ b/modules/reference_modules_unused/jamfpro_prerequisites/variables.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 variable "prefix" {
   type    = string
   default = "Prerequisites - "

--- a/modules/trusted_access_outcomes/endpoint_compliance/computers/mac_800_171_benchmark/main.tf
+++ b/modules/trusted_access_outcomes/endpoint_compliance/computers/mac_800_171_benchmark/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Call Terraform provider
 terraform {
   required_providers {

--- a/modules/trusted_access_outcomes/endpoint_compliance/computers/mac_800_171_benchmark/variables.tf
+++ b/modules/trusted_access_outcomes/endpoint_compliance/computers/mac_800_171_benchmark/variables.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Define miscellaneous variables
 variable "prefix" {
   type    = string

--- a/modules/trusted_access_outcomes/endpoint_compliance/computers/mac_cis_lvl1_benchmark/main.tf
+++ b/modules/trusted_access_outcomes/endpoint_compliance/computers/mac_cis_lvl1_benchmark/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Call Terraform provider
 terraform {
   required_providers {

--- a/modules/trusted_access_outcomes/endpoint_compliance/computers/mac_cis_lvl1_benchmark/variables.tf
+++ b/modules/trusted_access_outcomes/endpoint_compliance/computers/mac_cis_lvl1_benchmark/variables.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Define miscellaneous variables
 variable "prefix" {
   type    = string

--- a/modules/trusted_access_outcomes/endpoint_compliance/computers/mac_cmmc_lvl1_benchmark/main.tf
+++ b/modules/trusted_access_outcomes/endpoint_compliance/computers/mac_cmmc_lvl1_benchmark/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Call Terraform provider
 terraform {
   required_providers {

--- a/modules/trusted_access_outcomes/endpoint_compliance/computers/mac_cmmc_lvl1_benchmark/variables.tf
+++ b/modules/trusted_access_outcomes/endpoint_compliance/computers/mac_cmmc_lvl1_benchmark/variables.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Define miscellaneous variables
 variable "prefix" {
   type    = string

--- a/modules/trusted_access_outcomes/endpoint_compliance/computers/mac_stig_benchmark/main.tf
+++ b/modules/trusted_access_outcomes/endpoint_compliance/computers/mac_stig_benchmark/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Call Terraform provider
 terraform {
   required_providers {

--- a/modules/trusted_access_outcomes/endpoint_compliance/computers/mac_stig_benchmark/variables.tf
+++ b/modules/trusted_access_outcomes/endpoint_compliance/computers/mac_stig_benchmark/variables.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Define miscellaneous variables
 variable "prefix" {
   type    = string

--- a/modules/trusted_access_outcomes/endpoint_compliance/devices/mobile_cis_lvl1_benchmark/main.tf
+++ b/modules/trusted_access_outcomes/endpoint_compliance/devices/mobile_cis_lvl1_benchmark/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Call Terraform provider
 terraform {
   required_providers {

--- a/modules/trusted_access_outcomes/endpoint_compliance/devices/mobile_cis_lvl1_benchmark/variables.tf
+++ b/modules/trusted_access_outcomes/endpoint_compliance/devices/mobile_cis_lvl1_benchmark/variables.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Define miscellaneous variables
 variable "prefix" {
   type    = string

--- a/modules/trusted_access_outcomes/endpoint_compliance/devices/mobile_stig_benchmark/main.tf
+++ b/modules/trusted_access_outcomes/endpoint_compliance/devices/mobile_stig_benchmark/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Call Terraform provider
 terraform {
   required_providers {

--- a/modules/trusted_access_outcomes/endpoint_compliance/devices/mobile_stig_benchmark/variables.tf
+++ b/modules/trusted_access_outcomes/endpoint_compliance/devices/mobile_stig_benchmark/variables.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Define miscellaneous variables
 variable "prefix" {
   type    = string

--- a/modules/trusted_access_outcomes/jsc_alternatives/jsc_dp_only/main.tf
+++ b/modules/trusted_access_outcomes/jsc_alternatives/jsc_dp_only/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Call Terraform provider
 terraform {
   required_providers {

--- a/modules/trusted_access_outcomes/jsc_alternatives/jsc_dp_only/variables.tf
+++ b/modules/trusted_access_outcomes/jsc_alternatives/jsc_dp_only/variables.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 variable "jamfpro_instance_url" {
   type      = string
   sensitive = true

--- a/modules/trusted_access_outcomes/jsc_alternatives/jsc_mtd_dp_only/main.tf
+++ b/modules/trusted_access_outcomes/jsc_alternatives/jsc_mtd_dp_only/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Call Terraform provider
 terraform {
   required_providers {

--- a/modules/trusted_access_outcomes/jsc_alternatives/jsc_mtd_dp_only/variables.tf
+++ b/modules/trusted_access_outcomes/jsc_alternatives/jsc_mtd_dp_only/variables.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 variable "jamfpro_instance_url" {
   type      = string
   sensitive = true

--- a/modules/trusted_access_outcomes/jsc_alternatives/jsc_mtd_only/main.tf
+++ b/modules/trusted_access_outcomes/jsc_alternatives/jsc_mtd_only/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Call Terraform provider
 terraform {
   required_providers {

--- a/modules/trusted_access_outcomes/jsc_alternatives/jsc_mtd_only/variables.tf
+++ b/modules/trusted_access_outcomes/jsc_alternatives/jsc_mtd_only/variables.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 variable "jamfpro_instance_url" {
   type      = string
   sensitive = true

--- a/modules/trusted_access_outcomes/jsc_alternatives/jsc_network_relay/main.tf
+++ b/modules/trusted_access_outcomes/jsc_alternatives/jsc_network_relay/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Call Terraform provider
 terraform {
   required_providers {

--- a/modules/trusted_access_outcomes/jsc_alternatives/jsc_network_relay/variables.tf
+++ b/modules/trusted_access_outcomes/jsc_alternatives/jsc_network_relay/variables.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 variable "jamfpro_instance_url" {
   type      = string
   sensitive = true

--- a/modules/trusted_access_outcomes/jsc_alternatives/jsc_ztna/main.tf
+++ b/modules/trusted_access_outcomes/jsc_alternatives/jsc_ztna/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Call Terraform provider
 terraform {
   required_providers {

--- a/modules/trusted_access_outcomes/jsc_alternatives/jsc_ztna/variables.tf
+++ b/modules/trusted_access_outcomes/jsc_alternatives/jsc_ztna/variables.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 variable "jamfpro_instance_url" {
   type      = string
   sensitive = true

--- a/modules/trusted_access_outcomes/jsc_alternatives/jsc_ztna_dp_only/main.tf
+++ b/modules/trusted_access_outcomes/jsc_alternatives/jsc_ztna_dp_only/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Call Terraform provider
 terraform {
   required_providers {

--- a/modules/trusted_access_outcomes/jsc_alternatives/jsc_ztna_dp_only/variables.tf
+++ b/modules/trusted_access_outcomes/jsc_alternatives/jsc_ztna_dp_only/variables.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 variable "jamfpro_instance_url" {
   type      = string
   sensitive = true

--- a/modules/trusted_access_outcomes/jsc_alternatives/jsc_ztna_mtd_only/main.tf
+++ b/modules/trusted_access_outcomes/jsc_alternatives/jsc_ztna_mtd_only/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Call Terraform provider
 terraform {
   required_providers {

--- a/modules/trusted_access_outcomes/jsc_alternatives/jsc_ztna_mtd_only/variables.tf
+++ b/modules/trusted_access_outcomes/jsc_alternatives/jsc_ztna_mtd_only/variables.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 
 variable "jamfpro_instance_url" {
   type      = string

--- a/modules/trusted_access_outcomes/local_macos_account_security/main.tf
+++ b/modules/trusted_access_outcomes/local_macos_account_security/main.tf
@@ -1,1 +1,2 @@
+# Copyright 2024, Jamf
 

--- a/modules/trusted_access_outcomes/passwordless_sso/main.tf
+++ b/modules/trusted_access_outcomes/passwordless_sso/main.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Call Terraform provider
 terraform {
   required_providers {

--- a/modules/trusted_access_outcomes/passwordless_sso/variables.tf
+++ b/modules/trusted_access_outcomes/passwordless_sso/variables.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Define miscellaneous variables
 variable "prefix" {
   type    = string

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ## Define Jamf Pro provider variables (populated by .tfvars file)
 variable "jamfpro_instance_url" {
   description = "Jamf Pro Instance name."

--- a/variables_ej_saas_tenancy.tf
+++ b/variables_ej_saas_tenancy.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 variable "KeyName" {
   type        = string
   sensitive   = false

--- a/variables_onboarder_wizard.tf
+++ b/variables_onboarder_wizard.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 variable "install_chrome" {
   type    = bool
   default = false

--- a/variables_protectformacOS.tf
+++ b/variables_protectformacOS.tf
@@ -1,3 +1,4 @@
+# Copyright 2024, Jamf
 ### Define Jamf Protect for macOS integration
 variable "include_jamf_protect_for_macOS" {
   type    = bool


### PR DESCRIPTION
There are no functional changes. I checked out staging and ran this on it...

ExperienceJamf-Terraform % find . -type f -name "*.tf" -exec sed -i '' '1i\
# Copyright 2024, Jamf

' {} +

The open source policy requires that all source files include a copyright line. 