### PR TITLE
TRIVIAL Update SonarQube project in catalog file [Backstage-generated]

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -2,6 +2,8 @@ apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
   name: TJE-Terraform
+  annotations:
+    sonarqube.org/project-key: com.jamf.ce.terraform-jamf-platform
 spec:
   type: provisioning
   lifecycle: experimental


### PR DESCRIPTION
Add SonarQube project key annotation to `catalog-info.yaml` to link project in [Backstage](https://portal.jamf.build).