### PR TITLE
change to path.module and removal of legacy support_files_path_prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ jamfpro_auth_method   = "oauth2"
 jamfpro_client_id     = ""
 jamfpro_client_secret = ""
 
-
 ## Jamf Security Cloud (RADAR) Account Details
 jsc_username          = ""
 jsc_password          = ""
@@ -51,13 +50,9 @@ block_page_logo       = ""
 tje_okta_clientid  = ""
 tje_okta_orgdomain = ""
 
-# File path prefix for Terraform directory
-support_files_path_prefix = "" ## Path to your directory - example: /Users/<youruser>/filename/
-
 ##################################
 ##### ONBOARDER MODULE KNOBS #####
 ##################################
-
 
 ## (Jamf Pro) General Settings Knobs ##
 include_qol_smart_groups             = false
@@ -97,8 +92,6 @@ include_microsoft_edge       = false
 include_text_expander        = false
 include_nudge                = false
 app_installers               = []
-
-
 
 ## Jamf Protect Knobs ##
 include_jamf_protect_trial_kickstart = false

--- a/main.tf
+++ b/main.tf
@@ -37,27 +37,23 @@ provider "jsc" {
 
 # Onboarder Modules
 module "onboarder-all" {
-  count                     = var.include_onboarder_all == true ? 1 : 0
-  source                    = "./modules/onboarder-all"
-  support_files_path_prefix = var.support_files_path_prefix
+  count  = var.include_onboarder_all == true ? 1 : 0
+  source = "./modules/onboarder-all"
 }
 
 module "onboarder-management-macOS" {
-  count                     = var.include_onboarder_management_macOS == true ? 1 : 0
-  source                    = "./modules/onboarder-management-macOS"
-  support_files_path_prefix = var.support_files_path_prefix
+  count  = var.include_onboarder_management_macOS == true ? 1 : 0
+  source = "./modules/onboarder-management-macOS"
 }
 
 module "onboarder-management-mobile" {
-  count                     = var.include_onboarder_management_mobile == true ? 1 : 0
-  source                    = "./modules/onboarder-management-mobile"
-  support_files_path_prefix = var.support_files_path_prefix
+  count  = var.include_onboarder_management_mobile == true ? 1 : 0
+  source = "./modules/onboarder-management-mobile"
 }
 
 module "onboarder-app-installers" {
-  count                     = var.include_onboarder_app_installers == true ? 1 : 0
-  source                    = "./modules/onboarder-app-installers"
-  support_files_path_prefix = var.support_files_path_prefix
+  count  = var.include_onboarder_app_installers == true ? 1 : 0
+  source = "./modules/onboarder-app-installers"
 }
 
 ## Initialize common modules
@@ -76,39 +72,33 @@ module "configuration-jamf-pro-jamf-protect" {
 }
 
 module "compliance-macOS-cis-level-1" {
-  count                     = var.include_mac_cis_lvl1_benchmark == true ? 1 : 0
-  source                    = "./modules/compliance-macOS-cis-level-1"
-  support_files_path_prefix = var.support_files_path_prefix
+  count  = var.include_mac_cis_lvl1_benchmark == true ? 1 : 0
+  source = "./modules/compliance-macOS-cis-level-1"
 }
 
 module "compliance-iOS-cis-level-1" {
-  count                     = var.include_mobile_cis_lvl1_benchmark == true ? 1 : 0
-  source                    = "./modules/compliance-iOS-cis-level-1"
-  support_files_path_prefix = var.support_files_path_prefix
+  count  = var.include_mobile_cis_lvl1_benchmark == true ? 1 : 0
+  source = "./modules/compliance-iOS-cis-level-1"
 }
 
 module "compliance-macOS-disa-stig" {
-  count                     = var.include_mac_stig_benchmark == true ? 1 : 0
-  source                    = "./modules/compliance-macOS-disa-stig"
-  support_files_path_prefix = var.support_files_path_prefix
+  count  = var.include_mac_stig_benchmark == true ? 1 : 0
+  source = "./modules/compliance-macOS-disa-stig"
 }
 
 module "compliance-iOS-disa-stig" {
-  count                     = var.include_mobile_stig_benchmark == true ? 1 : 0
-  source                    = "./modules/compliance-iOS-disa-stig"
-  support_files_path_prefix = var.support_files_path_prefix
+  count  = var.include_mobile_stig_benchmark == true ? 1 : 0
+  source = "./modules/compliance-iOS-disa-stig"
 }
 
 module "compliance-macOS-nist-800-171" {
-  count                     = var.include_mac_800_171_benchmark == true ? 1 : 0
-  source                    = "./modules/compliance-macOS-nist-800-171"
-  support_files_path_prefix = var.support_files_path_prefix
+  count  = var.include_mac_800_171_benchmark == true ? 1 : 0
+  source = "./modules/compliance-macOS-nist-800-171"
 }
 
 module "compliance-macOS-cmmc-level-1" {
-  count                     = var.include_mac_cmmc_lvl1_benchmark == true ? 1 : 0
-  source                    = "./modules/compliance-macOS-cmmc-level-1"
-  support_files_path_prefix = var.support_files_path_prefix
+  count  = var.include_mac_cmmc_lvl1_benchmark == true ? 1 : 0
+  source = "./modules/compliance-macOS-cmmc-level-1"
 }
 
 module "configuration-jamf-pro-smart-groups" {
@@ -147,9 +137,8 @@ module "endpoint-security-macOS-microsoft-defender" {
 }
 
 module "management-macOS-SSOe-Okta" {
-  count                     = var.include_ssoe_okta == true ? 1 : 0
-  source                    = "./modules/management-macOS-SSOe-Okta"
-  support_files_path_prefix = var.support_files_path_prefix
+  count  = var.include_ssoe_okta == true ? 1 : 0
+  source = "./modules/management-macOS-SSOe-Okta"
 }
 
 module "endpoint-security-macOS-crowdstrike" {

--- a/modules/compliance-iOS-cis-level-1/main.tf
+++ b/modules/compliance-iOS-cis-level-1/main.tf
@@ -63,9 +63,9 @@ resource "jamfpro_smart_mobile_device_group" "group_ios18" {
 ## Define configuration profile details for iOS 17
 locals {
   ios17_cis_lvl1_dict = {
-    "Application Access" = "${var.support_files_path_prefix}modules/compliance-iOS-cis-level-1/support_files/mobile_configuration_profiles/iOS17_cis_lvl1_enterprise-applicationaccess.mobileconfig"
-    "Mail Policy"        = "${var.support_files_path_prefix}modules/compliance-iOS-cis-level-1/support_files/mobile_configuration_profiles/iOS17_cis_lvl1_enterprise-mail.managed.mobileconfig"
-    "Password Policy"    = "${var.support_files_path_prefix}modules/compliance-iOS-cis-level-1/support_files/mobile_configuration_profiles/iOS17_cis_lvl1_enterprise-mobiledevice.passwordpolicy.mobileconfig"
+    "Application Access" = "${path.module}/support_files/mobile_configuration_profiles/iOS17_cis_lvl1_enterprise-applicationaccess.mobileconfig"
+    "Mail Policy"        = "${path.module}/support_files/mobile_configuration_profiles/iOS17_cis_lvl1_enterprise-mail.managed.mobileconfig"
+    "Password Policy"    = "${path.module}/support_files/mobile_configuration_profiles/iOS17_cis_lvl1_enterprise-mobiledevice.passwordpolicy.mobileconfig"
   }
 }
 
@@ -89,9 +89,9 @@ resource "jamfpro_mobile_device_configuration_profile_plist" "config_ios17" {
 ## Define configuration profile details for iOS 18
 locals {
   ios18_cis_lvl1_dict = {
-    "Application Access" = "${var.support_files_path_prefix}modules/compliance-iOS-cis-level-1/support_files/mobile_configuration_profiles/iOS18_cis_lvl1_enterprise-applicationaccess.mobileconfig"
-    "Mail Policy"        = "${var.support_files_path_prefix}modules/compliance-iOS-cis-level-1/support_files/mobile_configuration_profiles/iOS18_cis_lvl1_enterprise-mail.managed.mobileconfig"
-    "Password Policy"    = "${var.support_files_path_prefix}modules/compliance-iOS-cis-level-1/support_files/mobile_configuration_profiles/iOS18_cis_lvl1_enterprise-mobiledevice.passwordpolicy.mobileconfig"
+    "Application Access" = "${path.module}/support_files/mobile_configuration_profiles/iOS18_cis_lvl1_enterprise-applicationaccess.mobileconfig"
+    "Mail Policy"        = "${path.module}/support_files/mobile_configuration_profiles/iOS18_cis_lvl1_enterprise-mail.managed.mobileconfig"
+    "Password Policy"    = "${path.module}/support_files/mobile_configuration_profiles/iOS18_cis_lvl1_enterprise-mobiledevice.passwordpolicy.mobileconfig"
   }
 }
 

--- a/modules/compliance-iOS-disa-stig/main.tf
+++ b/modules/compliance-iOS-disa-stig/main.tf
@@ -65,10 +65,10 @@ resource "jamfpro_smart_mobile_device_group" "group_ios17" {
 ## Define configuration profile details for iOS 17
 locals {
   ios17_stig_dict = {
-    "Application Access"            = "${var.support_files_path_prefix}modules/compliance-iOS-disa-stig/support_files/mobile_configuration_profiles/iOS17_ios_stig-applicationaccess.mobileconfig"
-    "Exchange Active Sync Settings" = "${var.support_files_path_prefix}modules/compliance-iOS-disa-stig/support_files/mobile_configuration_profiles/iOS17_ios_stig-eas.account.mobileconfig"
-    "Mail Policy"                   = "${var.support_files_path_prefix}modules/compliance-iOS-disa-stig/support_files/mobile_configuration_profiles/iOS17_ios_stig-mail.managed.mobileconfig"
-    "Password Policy"               = "${var.support_files_path_prefix}modules/compliance-iOS-disa-stig/support_files/mobile_configuration_profiles/iOS17_ios_stig-mobiledevice.passwordpolicy.mobileconfig"
+    "Application Access"            = "${path.module}/support_files/mobile_configuration_profiles/iOS17_ios_stig-applicationaccess.mobileconfig"
+    "Exchange Active Sync Settings" = "${path.module}/support_files/mobile_configuration_profiles/iOS17_ios_stig-eas.account.mobileconfig"
+    "Mail Policy"                   = "${path.module}/support_files/mobile_configuration_profiles/iOS17_ios_stig-mail.managed.mobileconfig"
+    "Password Policy"               = "${path.module}/support_files/mobile_configuration_profiles/iOS17_ios_stig-mobiledevice.passwordpolicy.mobileconfig"
   }
 }
 
@@ -92,10 +92,10 @@ resource "jamfpro_mobile_device_configuration_profile_plist" "config_ios17" {
 ## Define configuration profile details for iOS 18
 # locals {
 #   ios18_stig_dict = {
-#     "Application Access"            = "${var.support_files_path_prefix}modules/compliance-iOS-disa-stig/support_files/mobile_configuration_profiles/iOS18_ios_stig-applicationaccess.mobileconfig"
-#     "Exchange Active Sync Settings" = "${var.support_files_path_prefix}modules/compliance-iOS-disa-stig/support_files/mobile_configuration_profiles/iOS18_ios_stig-eas.account.mobileconfig"
-#     "Mail Policy"                   = "${var.support_files_path_prefix}modules/compliance-iOS-disa-stig/support_files/mobile_configuration_profiles/iOS18_ios_stig-mail.managed.mobileconfig"
-#     "Password Policy"               = "${var.support_files_path_prefix}modules/compliance-iOS-disa-stig/support_files/mobile_configuration_profiles/iOS18_ios_stig-mobiledevice.passwordpolicy.mobileconfig"
+#     "Application Access"            = "${path.module}/support_files/mobile_configuration_profiles/iOS18_ios_stig-applicationaccess.mobileconfig"
+#     "Exchange Active Sync Settings" = "${path.module}/support_files/mobile_configuration_profiles/iOS18_ios_stig-eas.account.mobileconfig"
+#     "Mail Policy"                   = "${path.module}/support_files/mobile_configuration_profiles/iOS18_ios_stig-mail.managed.mobileconfig"
+#     "Password Policy"               = "${path.module}/support_files/mobile_configuration_profiles/iOS18_ios_stig-mobiledevice.passwordpolicy.mobileconfig"
 #   }
 # }
 

--- a/modules/compliance-macOS-cis-level-1/main.tf
+++ b/modules/compliance-macOS-cis-level-1/main.tf
@@ -28,7 +28,7 @@ resource "jamfpro_category" "category_sequoia_cis_lvl1_benchmarks" {
 resource "jamfpro_script" "script_sonoma_cis_lvl1_compliance" {
   name            = "Sonoma - CIS Level 1 Compliance [${random_integer.entropy.result}]"
   priority        = "AFTER"
-  script_contents = file("${var.support_files_path_prefix}modules/compliance-macOS-cis-level-1/support_files/computer_scripts/sonoma_cis_lvl1_compliance.sh")
+  script_contents = file("${path.module}/support_files/computer_scripts/sonoma_cis_lvl1_compliance.sh")
   category_id     = jamfpro_category.category_sonoma_cis_lvl1_benchmarks.id
   info            = "This script will apply a set of rules related to the CIS Level 1 benchmark for macOS Sonoma"
 }
@@ -36,7 +36,7 @@ resource "jamfpro_script" "script_sonoma_cis_lvl1_compliance" {
 resource "jamfpro_script" "script_sequoia_cis_lvl1_compliance" {
   name            = "Sequoia - CIS Level 1 Compliance [${random_integer.entropy.result}]"
   priority        = "AFTER"
-  script_contents = file("${var.support_files_path_prefix}modules/compliance-macOS-cis-level-1/support_files/computer_scripts/sequoia_cis_lvl1_compliance.sh")
+  script_contents = file("${path.module}/support_files/computer_scripts/sequoia_cis_lvl1_compliance.sh")
   category_id     = jamfpro_category.category_sequoia_cis_lvl1_benchmarks.id
   info            = "This script will apply a set of rules related to the CIS Level 1 benchmark for macOS Sequoia"
 }
@@ -48,7 +48,7 @@ resource "jamfpro_computer_extension_attribute" "ea_cis_lvl1_failed_count" {
   enabled                = true
   data_type              = "INTEGER"
   inventory_display_type = "EXTENSION_ATTRIBUTES"
-  script_contents        = file("${var.support_files_path_prefix}modules/compliance-macOS-cis-level-1/support_files/computer_extension_attributes/compliance-FailedResultsCount.sh")
+  script_contents        = file("${path.module}/support_files/computer_extension_attributes/compliance-FailedResultsCount.sh")
 }
 
 resource "jamfpro_computer_extension_attribute" "ea_cis_lvl1_failed_list" {
@@ -57,7 +57,7 @@ resource "jamfpro_computer_extension_attribute" "ea_cis_lvl1_failed_list" {
   enabled                = true
   data_type              = "STRING"
   inventory_display_type = "EXTENSION_ATTRIBUTES"
-  script_contents        = file("${var.support_files_path_prefix}modules/compliance-macOS-cis-level-1/support_files/computer_extension_attributes/compliance-FailedResultsList.sh")
+  script_contents        = file("${path.module}/support_files/computer_extension_attributes/compliance-FailedResultsList.sh")
 }
 
 resource "jamfpro_computer_extension_attribute" "ea_cis_lvl1_version" {
@@ -66,7 +66,7 @@ resource "jamfpro_computer_extension_attribute" "ea_cis_lvl1_version" {
   enabled                = true
   data_type              = "STRING"
   inventory_display_type = "EXTENSION_ATTRIBUTES"
-  script_contents        = file("${var.support_files_path_prefix}modules/compliance-macOS-cis-level-1/support_files/computer_extension_attributes/compliance-version.sh")
+  script_contents        = file("${path.module}/support_files/computer_extension_attributes/compliance-version.sh")
 }
 
 ## Create Smart Computer Groups
@@ -302,19 +302,19 @@ resource "jamfpro_policy" "policy_sequoia_cis_lvl1_remediation" {
 ## Define configuration profile details for Sonoma
 locals {
   sonoma_cis_lvl1_dict = {
-    "Application Access"    = "${var.support_files_path_prefix}modules/compliance-macOS-cis-level-1/support_files/computer_config_profiles/sonoma_cis_lvl1-applicationaccess.mobileconfig"
-    "Control Center"        = "${var.support_files_path_prefix}modules/compliance-macOS-cis-level-1/support_files/computer_config_profiles/sonoma_cis_lvl1-controlcenter.mobileconfig"
-    "Login Window"          = "${var.support_files_path_prefix}modules/compliance-macOS-cis-level-1/support_files/computer_config_profiles/sonoma_cis_lvl1-loginwindow.mobileconfig"
-    "MCX"                   = "${var.support_files_path_prefix}modules/compliance-macOS-cis-level-1/support_files/computer_config_profiles/sonoma_cis_lvl1-MCX.mobileconfig"
-    "Password Policy"       = "${var.support_files_path_prefix}modules/compliance-macOS-cis-level-1/support_files/computer_config_profiles/sonoma_cis_lvl1-mobiledevice.passwordpolicy.mobileconfig"
-    "Safari"                = "${var.support_files_path_prefix}modules/compliance-macOS-cis-level-1/support_files/computer_config_profiles/sonoma_cis_lvl1-Safari.mobileconfig"
-    "Screen Saver"          = "${var.support_files_path_prefix}modules/compliance-macOS-cis-level-1/support_files/computer_config_profiles/sonoma_cis_lvl1-screensaver.mobileconfig"
-    "Firewall"              = "${var.support_files_path_prefix}modules/compliance-macOS-cis-level-1/support_files/computer_config_profiles/sonoma_cis_lvl1-security.firewall.mobileconfig"
-    "Siri"                  = "${var.support_files_path_prefix}modules/compliance-macOS-cis-level-1/support_files/computer_config_profiles/sonoma_cis_lvl1-Siri.mobileconfig"
-    "Software Update"       = "${var.support_files_path_prefix}modules/compliance-macOS-cis-level-1/support_files/computer_config_profiles/sonoma_cis_lvl1-SoftwareUpdate.mobileconfig"
-    "System Policy Control" = "${var.support_files_path_prefix}modules/compliance-macOS-cis-level-1/support_files/computer_config_profiles/sonoma_cis_lvl1-systempolicy.control.mobileconfig"
-    "Terminal"              = "${var.support_files_path_prefix}modules/compliance-macOS-cis-level-1/support_files/computer_config_profiles/sonoma_cis_lvl1-Terminal.mobileconfig"
-    "Managed Client"        = "${var.support_files_path_prefix}modules/compliance-macOS-cis-level-1/support_files/computer_config_profiles/sonoma_cis_lvl1-timed.mobileconfig"
+    "Application Access"    = "${path.module}/support_files/computer_config_profiles/sonoma_cis_lvl1-applicationaccess.mobileconfig"
+    "Control Center"        = "${path.module}/support_files/computer_config_profiles/sonoma_cis_lvl1-controlcenter.mobileconfig"
+    "Login Window"          = "${path.module}/support_files/computer_config_profiles/sonoma_cis_lvl1-loginwindow.mobileconfig"
+    "MCX"                   = "${path.module}/support_files/computer_config_profiles/sonoma_cis_lvl1-MCX.mobileconfig"
+    "Password Policy"       = "${path.module}/support_files/computer_config_profiles/sonoma_cis_lvl1-mobiledevice.passwordpolicy.mobileconfig"
+    "Safari"                = "${path.module}/support_files/computer_config_profiles/sonoma_cis_lvl1-Safari.mobileconfig"
+    "Screen Saver"          = "${path.module}/support_files/computer_config_profiles/sonoma_cis_lvl1-screensaver.mobileconfig"
+    "Firewall"              = "${path.module}/support_files/computer_config_profiles/sonoma_cis_lvl1-security.firewall.mobileconfig"
+    "Siri"                  = "${path.module}/support_files/computer_config_profiles/sonoma_cis_lvl1-Siri.mobileconfig"
+    "Software Update"       = "${path.module}/support_files/computer_config_profiles/sonoma_cis_lvl1-SoftwareUpdate.mobileconfig"
+    "System Policy Control" = "${path.module}/support_files/computer_config_profiles/sonoma_cis_lvl1-systempolicy.control.mobileconfig"
+    "Terminal"              = "${path.module}/support_files/computer_config_profiles/sonoma_cis_lvl1-Terminal.mobileconfig"
+    "Managed Client"        = "${path.module}/support_files/computer_config_profiles/sonoma_cis_lvl1-timed.mobileconfig"
   }
 }
 
@@ -339,22 +339,22 @@ resource "jamfpro_macos_configuration_profile_plist" "sonoma_cis_lvl1" {
 ## Define configuration profile details for Sequoia part 1
 locals {
   sequoia_cis_lvl1_dict = {
-    "Accessibility"          = "${var.support_files_path_prefix}modules/compliance-macOS-cis-level-1/support_files/computer_config_profiles/sequoia_cis_lvl1-Accessibility.mobileconfig"
-    "Application Access"     = "${var.support_files_path_prefix}modules/compliance-macOS-cis-level-1/support_files/computer_config_profiles/sequoia_cis_lvl1-applicationaccess.mobileconfig"
-    "Assistant"              = "${var.support_files_path_prefix}modules/compliance-macOS-cis-level-1/support_files/computer_config_profiles/sequoia_cis_lvl1-assistant.support.mobileconfig"
-    "Control Center"         = "${var.support_files_path_prefix}modules/compliance-macOS-cis-level-1/support_files/computer_config_profiles/sequoia_cis_lvl1-controlcenter.mobileconfig"
-    "Login Window"           = "${var.support_files_path_prefix}modules/compliance-macOS-cis-level-1/support_files/computer_config_profiles/sequoia_cis_lvl1-loginwindow.mobileconfig"
-    "MCX"                    = "${var.support_files_path_prefix}modules/compliance-macOS-cis-level-1/support_files/computer_config_profiles/sequoia_cis_lvl1-MCX.mobileconfig"
-    "Password Policy"        = "${var.support_files_path_prefix}modules/compliance-macOS-cis-level-1/support_files/computer_config_profiles/sequoia_cis_lvl1-mobiledevice.passwordpolicy.mobileconfig"
-    "Safari"                 = "${var.support_files_path_prefix}modules/compliance-macOS-cis-level-1/support_files/computer_config_profiles/sequoia_cis_lvl1-Safari.mobileconfig"
-    "Screen Saver"           = "${var.support_files_path_prefix}modules/compliance-macOS-cis-level-1/support_files/computer_config_profiles/sequoia_cis_lvl1-screensaver.mobileconfig"
-    "Firewall"               = "${var.support_files_path_prefix}modules/compliance-macOS-cis-level-1/support_files/computer_config_profiles/sequoia_cis_lvl1-security.firewall.mobileconfig"
-    "Siri"                   = "${var.support_files_path_prefix}modules/compliance-macOS-cis-level-1/support_files/computer_config_profiles/sequoia_cis_lvl1-Siri.mobileconfig"
-    "Software Update"        = "${var.support_files_path_prefix}modules/compliance-macOS-cis-level-1/support_files/computer_config_profiles/sequoia_cis_lvl1-SoftwareUpdate.mobileconfig"
-    "Submit Diagnostic Info" = "${var.support_files_path_prefix}modules/compliance-macOS-cis-level-1/support_files/computer_config_profiles/sequoia_cis_lvl1-SubmitDiagInfo.mobileconfig"
-    "System Policy Control"  = "${var.support_files_path_prefix}modules/compliance-macOS-cis-level-1/support_files/computer_config_profiles/sequoia_cis_lvl1-systempolicy.control.mobileconfig"
-    "Terminal"               = "${var.support_files_path_prefix}modules/compliance-macOS-cis-level-1/support_files/computer_config_profiles/sequoia_cis_lvl1-Terminal.mobileconfig"
-    "Managed Client"         = "${var.support_files_path_prefix}modules/compliance-macOS-cis-level-1/support_files/computer_config_profiles/sequoia_cis_lvl1-timed.mobileconfig"
+    "Accessibility"          = "${path.module}/support_files/computer_config_profiles/sequoia_cis_lvl1-Accessibility.mobileconfig"
+    "Application Access"     = "${path.module}/support_files/computer_config_profiles/sequoia_cis_lvl1-applicationaccess.mobileconfig"
+    "Assistant"              = "${path.module}/support_files/computer_config_profiles/sequoia_cis_lvl1-assistant.support.mobileconfig"
+    "Control Center"         = "${path.module}/support_files/computer_config_profiles/sequoia_cis_lvl1-controlcenter.mobileconfig"
+    "Login Window"           = "${path.module}/support_files/computer_config_profiles/sequoia_cis_lvl1-loginwindow.mobileconfig"
+    "MCX"                    = "${path.module}/support_files/computer_config_profiles/sequoia_cis_lvl1-MCX.mobileconfig"
+    "Password Policy"        = "${path.module}/support_files/computer_config_profiles/sequoia_cis_lvl1-mobiledevice.passwordpolicy.mobileconfig"
+    "Safari"                 = "${path.module}/support_files/computer_config_profiles/sequoia_cis_lvl1-Safari.mobileconfig"
+    "Screen Saver"           = "${path.module}/support_files/computer_config_profiles/sequoia_cis_lvl1-screensaver.mobileconfig"
+    "Firewall"               = "${path.module}/support_files/computer_config_profiles/sequoia_cis_lvl1-security.firewall.mobileconfig"
+    "Siri"                   = "${path.module}/support_files/computer_config_profiles/sequoia_cis_lvl1-Siri.mobileconfig"
+    "Software Update"        = "${path.module}/support_files/computer_config_profiles/sequoia_cis_lvl1-SoftwareUpdate.mobileconfig"
+    "Submit Diagnostic Info" = "${path.module}/support_files/computer_config_profiles/sequoia_cis_lvl1-SubmitDiagInfo.mobileconfig"
+    "System Policy Control"  = "${path.module}/support_files/computer_config_profiles/sequoia_cis_lvl1-systempolicy.control.mobileconfig"
+    "Terminal"               = "${path.module}/support_files/computer_config_profiles/sequoia_cis_lvl1-Terminal.mobileconfig"
+    "Managed Client"         = "${path.module}/support_files/computer_config_profiles/sequoia_cis_lvl1-timed.mobileconfig"
 
   }
 }

--- a/modules/compliance-macOS-cmmc-level-1/main.tf
+++ b/modules/compliance-macOS-cmmc-level-1/main.tf
@@ -28,7 +28,7 @@ resource "jamfpro_category" "category_sequoia_cmmc_lvl1_benchmarks" {
 resource "jamfpro_script" "script_sonoma_cmmc_lvl1_compliance" {
   name            = "Sonoma - US CMMC 2.0 Level 1 Compliance [${random_integer.entropy.result}]"
   priority        = "AFTER"
-  script_contents = file("${var.support_files_path_prefix}modules/compliance-macOS-cmmc-level-1/support_files/computer_scripts/sonoma_cmmc_lvl1_compliance.sh")
+  script_contents = file("${path.module}/support_files/computer_scripts/sonoma_cmmc_lvl1_compliance.sh")
   category_id     = jamfpro_category.category_sonoma_cmmc_lvl1_benchmarks.id
   info            = "This script will apply a set of rules related to the US CMMC 2.0 Level 1 benchmark for macOS Sonoma"
 }
@@ -36,7 +36,7 @@ resource "jamfpro_script" "script_sonoma_cmmc_lvl1_compliance" {
 resource "jamfpro_script" "script_sequoia_cmmc_lvl1_compliance" {
   name            = "Sequoia - US CMMC 2.0 Level 1 Compliance [${random_integer.entropy.result}]"
   priority        = "AFTER"
-  script_contents = file("${var.support_files_path_prefix}modules/compliance-macOS-cmmc-level-1/support_files/computer_scripts/sequoia_cmmc_lvl1_compliance.sh")
+  script_contents = file("${path.module}/support_files/computer_scripts/sequoia_cmmc_lvl1_compliance.sh")
   category_id     = jamfpro_category.category_sequoia_cmmc_lvl1_benchmarks.id
   info            = "This script will apply a set of rules related to the US CMMC 2.0 Level 1 benchmark for macOS Sequoia"
 }
@@ -48,7 +48,7 @@ resource "jamfpro_computer_extension_attribute" "ea_cmmc_lvl1_failed_count" {
   enabled                = true
   data_type              = "INTEGER"
   inventory_display_type = "EXTENSION_ATTRIBUTES"
-  script_contents        = file("${var.support_files_path_prefix}modules/compliance-macOS-cmmc-level-1/support_files/computer_extension_attributes/compliance-FailedResultsCount.sh")
+  script_contents        = file("${path.module}/support_files/computer_extension_attributes/compliance-FailedResultsCount.sh")
 }
 
 resource "jamfpro_computer_extension_attribute" "ea_cmmc_lvl1_failed_list" {
@@ -57,7 +57,7 @@ resource "jamfpro_computer_extension_attribute" "ea_cmmc_lvl1_failed_list" {
   enabled                = true
   data_type              = "STRING"
   inventory_display_type = "EXTENSION_ATTRIBUTES"
-  script_contents        = file("${var.support_files_path_prefix}modules/compliance-macOS-cmmc-level-1/support_files/computer_extension_attributes/compliance-FailedResultsList.sh")
+  script_contents        = file("${path.module}/support_files/computer_extension_attributes/compliance-FailedResultsList.sh")
 }
 
 resource "jamfpro_computer_extension_attribute" "ea_cmmc_lvl1_version" {
@@ -66,7 +66,7 @@ resource "jamfpro_computer_extension_attribute" "ea_cmmc_lvl1_version" {
   enabled                = true
   data_type              = "STRING"
   inventory_display_type = "EXTENSION_ATTRIBUTES"
-  script_contents        = file("${var.support_files_path_prefix}modules/compliance-macOS-cmmc-level-1/support_files/computer_extension_attributes/compliance-version.sh")
+  script_contents        = file("${path.module}/support_files/computer_extension_attributes/compliance-version.sh")
 }
 
 ## Create Smart Computer Groups
@@ -302,19 +302,19 @@ resource "jamfpro_policy" "policy_sequoia_cmmc_lvl1_remediation" {
 ## Define configuration profile details for Sonoma
 locals {
   sonoma_cmmc_lvl1_dict = {
-    "Application Access"     = "${var.support_files_path_prefix}modules/compliance-macOS-cmmc-level-1/support_files/computer_config_profiles/Sonoma_cmmc_lvl1-applicationaccess.mobileconfig"
-    "Assistant"              = "${var.support_files_path_prefix}modules/compliance-macOS-cmmc-level-1/support_files/computer_config_profiles/Sonoma_cmmc_lvl1-assistant.support.mobileconfig"
-    "iCloud"                 = "${var.support_files_path_prefix}modules/compliance-macOS-cmmc-level-1/support_files/computer_config_profiles/Sonoma_cmmc_lvl1-icloud.managed.mobileconfig"
-    "Login Window"           = "${var.support_files_path_prefix}modules/compliance-macOS-cmmc-level-1/support_files/computer_config_profiles/Sonoma_cmmc_lvl1-loginwindow.mobileconfig"
-    "MCX"                    = "${var.support_files_path_prefix}modules/compliance-macOS-cmmc-level-1/support_files/computer_config_profiles/Sonoma_cmmc_lvl1-MCX.mobileconfig"
-    "Sharing Preferences"    = "${var.support_files_path_prefix}modules/compliance-macOS-cmmc-level-1/support_files/computer_config_profiles/Sonoma_cmmc_lvl1-preferences.sharing.SharingPrefsExtension.mobileconfig"
-    "Firewall"               = "${var.support_files_path_prefix}modules/compliance-macOS-cmmc-level-1/support_files/computer_config_profiles/Sonoma_cmmc_lvl1-security.firewall.mobileconfig"
-    "Security"               = "${var.support_files_path_prefix}modules/compliance-macOS-cmmc-level-1/support_files/computer_config_profiles/Sonoma_cmmc_lvl1-security.mobileconfig"
-    "Setup Assistant"        = "${var.support_files_path_prefix}modules/compliance-macOS-cmmc-level-1/support_files/computer_config_profiles/Sonoma_cmmc_lvl1-SetupAssistant.managed.mobileconfig"
-    "Software Update"        = "${var.support_files_path_prefix}modules/compliance-macOS-cmmc-level-1/support_files/computer_config_profiles/Sonoma_cmmc_lvl1-SoftwareUpdate.mobileconfig"
-    "Submit Diagnostic Info" = "${var.support_files_path_prefix}modules/compliance-macOS-cmmc-level-1/support_files/computer_config_profiles/Sonoma_cmmc_lvl1-SubmitDiagInfo.mobileconfig"
-    "System Policy Control"  = "${var.support_files_path_prefix}modules/compliance-macOS-cmmc-level-1/support_files/computer_config_profiles/Sonoma_cmmc_lvl1-systempolicy.control.mobileconfig"
-    "System Preferences"     = "${var.support_files_path_prefix}modules/compliance-macOS-cmmc-level-1/support_files/computer_config_profiles/Sonoma_cmmc_lvl1-systempreferences.mobileconfig"
+    "Application Access"     = "${path.module}/support_files/computer_config_profiles/Sonoma_cmmc_lvl1-applicationaccess.mobileconfig"
+    "Assistant"              = "${path.module}/support_files/computer_config_profiles/Sonoma_cmmc_lvl1-assistant.support.mobileconfig"
+    "iCloud"                 = "${path.module}/support_files/computer_config_profiles/Sonoma_cmmc_lvl1-icloud.managed.mobileconfig"
+    "Login Window"           = "${path.module}/support_files/computer_config_profiles/Sonoma_cmmc_lvl1-loginwindow.mobileconfig"
+    "MCX"                    = "${path.module}/support_files/computer_config_profiles/Sonoma_cmmc_lvl1-MCX.mobileconfig"
+    "Sharing Preferences"    = "${path.module}/support_files/computer_config_profiles/Sonoma_cmmc_lvl1-preferences.sharing.SharingPrefsExtension.mobileconfig"
+    "Firewall"               = "${path.module}/support_files/computer_config_profiles/Sonoma_cmmc_lvl1-security.firewall.mobileconfig"
+    "Security"               = "${path.module}/support_files/computer_config_profiles/Sonoma_cmmc_lvl1-security.mobileconfig"
+    "Setup Assistant"        = "${path.module}/support_files/computer_config_profiles/Sonoma_cmmc_lvl1-SetupAssistant.managed.mobileconfig"
+    "Software Update"        = "${path.module}/support_files/computer_config_profiles/Sonoma_cmmc_lvl1-SoftwareUpdate.mobileconfig"
+    "Submit Diagnostic Info" = "${path.module}/support_files/computer_config_profiles/Sonoma_cmmc_lvl1-SubmitDiagInfo.mobileconfig"
+    "System Policy Control"  = "${path.module}/support_files/computer_config_profiles/Sonoma_cmmc_lvl1-systempolicy.control.mobileconfig"
+    "System Preferences"     = "${path.module}/support_files/computer_config_profiles/Sonoma_cmmc_lvl1-systempreferences.mobileconfig"
   }
 }
 
@@ -343,7 +343,7 @@ resource "jamfpro_macos_configuration_profile_plist" "sonoma_cmmc_lvl1_smart_car
   category_id         = jamfpro_category.category_sonoma_cmmc_lvl1_benchmarks.id
   level               = "System"
 
-  payloads         = file("${var.support_files_path_prefix}modules/compliance-macOS-cmmc-level-1/support_files/computer_config_profiles/Sonoma_cmmc_lvl1-security.smartcard.mobileconfig")
+  payloads         = file("${path.module}/support_files/computer_config_profiles/Sonoma_cmmc_lvl1-security.smartcard.mobileconfig")
   payload_validate = false
 
   scope {
@@ -355,18 +355,18 @@ resource "jamfpro_macos_configuration_profile_plist" "sonoma_cmmc_lvl1_smart_car
 ## Define configuration profile details for Sequoia
 locals {
   sequoia_cmmc_lvl1_dict = {
-    "Accessibility"          = "${var.support_files_path_prefix}modules/compliance-macOS-cmmc-level-1/support_files/computer_config_profiles/Sequoia_cmmc_lvl1-Accessibility.mobileconfig"
-    "Application Access"     = "${var.support_files_path_prefix}modules/compliance-macOS-cmmc-level-1/support_files/computer_config_profiles/Sequoia_cmmc_lvl1-applicationaccess.mobileconfig"
-    "Assistant"              = "${var.support_files_path_prefix}modules/compliance-macOS-cmmc-level-1/support_files/computer_config_profiles/Sequoia_cmmc_lvl1-assistant.support.mobileconfig"
-    "iCloud"                 = "${var.support_files_path_prefix}modules/compliance-macOS-cmmc-level-1/support_files/computer_config_profiles/Sequoia_cmmc_lvl1-icloud.managed.mobileconfig"
-    "Login Window"           = "${var.support_files_path_prefix}modules/compliance-macOS-cmmc-level-1/support_files/computer_config_profiles/Sequoia_cmmc_lvl1-loginwindow.mobileconfig"
-    "MCX"                    = "${var.support_files_path_prefix}modules/compliance-macOS-cmmc-level-1/support_files/computer_config_profiles/Sequoia_cmmc_lvl1-MCX.mobileconfig"
-    "Firewall"               = "${var.support_files_path_prefix}modules/compliance-macOS-cmmc-level-1/support_files/computer_config_profiles/Sequoia_cmmc_lvl1-security.firewall.mobileconfig"
-    "Setup Assistant"        = "${var.support_files_path_prefix}modules/compliance-macOS-cmmc-level-1/support_files/computer_config_profiles/Sequoia_cmmc_lvl1-SetupAssistant.managed.mobileconfig"
-    "Software Update"        = "${var.support_files_path_prefix}modules/compliance-macOS-cmmc-level-1/support_files/computer_config_profiles/Sequoia_cmmc_lvl1-SoftwareUpdate.mobileconfig"
-    "Submit Diagnostic Info" = "${var.support_files_path_prefix}modules/compliance-macOS-cmmc-level-1/support_files/computer_config_profiles/Sequoia_cmmc_lvl1-SubmitDiagInfo.mobileconfig"
-    "System Policy Control"  = "${var.support_files_path_prefix}modules/compliance-macOS-cmmc-level-1/support_files/computer_config_profiles/Sequoia_cmmc_lvl1-systempolicy.control.mobileconfig"
-    "System Preferences"     = "${var.support_files_path_prefix}modules/compliance-macOS-cmmc-level-1/support_files/computer_config_profiles/Sequoia_cmmc_lvl1-systempreferences.mobileconfig"
+    "Accessibility"          = "${path.module}/support_files/computer_config_profiles/Sequoia_cmmc_lvl1-Accessibility.mobileconfig"
+    "Application Access"     = "${path.module}/support_files/computer_config_profiles/Sequoia_cmmc_lvl1-applicationaccess.mobileconfig"
+    "Assistant"              = "${path.module}/support_files/computer_config_profiles/Sequoia_cmmc_lvl1-assistant.support.mobileconfig"
+    "iCloud"                 = "${path.module}/support_files/computer_config_profiles/Sequoia_cmmc_lvl1-icloud.managed.mobileconfig"
+    "Login Window"           = "${path.module}/support_files/computer_config_profiles/Sequoia_cmmc_lvl1-loginwindow.mobileconfig"
+    "MCX"                    = "${path.module}/support_files/computer_config_profiles/Sequoia_cmmc_lvl1-MCX.mobileconfig"
+    "Firewall"               = "${path.module}/support_files/computer_config_profiles/Sequoia_cmmc_lvl1-security.firewall.mobileconfig"
+    "Setup Assistant"        = "${path.module}/support_files/computer_config_profiles/Sequoia_cmmc_lvl1-SetupAssistant.managed.mobileconfig"
+    "Software Update"        = "${path.module}/support_files/computer_config_profiles/Sequoia_cmmc_lvl1-SoftwareUpdate.mobileconfig"
+    "Submit Diagnostic Info" = "${path.module}/support_files/computer_config_profiles/Sequoia_cmmc_lvl1-SubmitDiagInfo.mobileconfig"
+    "System Policy Control"  = "${path.module}/support_files/computer_config_profiles/Sequoia_cmmc_lvl1-systempolicy.control.mobileconfig"
+    "System Preferences"     = "${path.module}/support_files/computer_config_profiles/Sequoia_cmmc_lvl1-systempreferences.mobileconfig"
   }
 }
 
@@ -396,7 +396,7 @@ resource "jamfpro_macos_configuration_profile_plist" "sequoia_cmmc_lvl1_smart_ca
   category_id         = jamfpro_category.category_sequoia_cmmc_lvl1_benchmarks.id
   level               = "System"
 
-  payloads         = file("${var.support_files_path_prefix}modules/compliance-macOS-cmmc-level-1/support_files/computer_config_profiles/Sequoia_cmmc_lvl1-security.smartcard.mobileconfig")
+  payloads         = file("${path.module}/support_files/computer_config_profiles/Sequoia_cmmc_lvl1-security.smartcard.mobileconfig")
   payload_validate = false
 
   scope {

--- a/modules/compliance-macOS-disa-stig/main.tf
+++ b/modules/compliance-macOS-disa-stig/main.tf
@@ -28,7 +28,7 @@ resource "jamfpro_category" "category_sequoia_stig_benchmarks" {
 resource "jamfpro_script" "script_sonoma_stig_compliance" {
   name            = "Sonoma - DISA STIG Compliance [${random_integer.entropy.result}]"
   priority        = "AFTER"
-  script_contents = file("${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_scripts/sonoma_stig_compliance.sh")
+  script_contents = file("${path.module}/support_files/computer_scripts/sonoma_stig_compliance.sh")
   category_id     = jamfpro_category.category_sonoma_stig_benchmarks.id
   info            = "This script will apply a set of rules related to the DISA STIG benchmark for macOS Sonoma"
 }
@@ -36,7 +36,7 @@ resource "jamfpro_script" "script_sonoma_stig_compliance" {
 resource "jamfpro_script" "script_sequoia_stig_compliance" {
   name            = "Sequoia - DISA STIG Compliance [${random_integer.entropy.result}]"
   priority        = "AFTER"
-  script_contents = file("${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_scripts/sequoia_stig_compliance.sh")
+  script_contents = file("${path.module}/support_files/computer_scripts/sequoia_stig_compliance.sh")
   category_id     = jamfpro_category.category_sequoia_stig_benchmarks.id
   info            = "This script will apply a set of rules related to the DISA STIG benchmark for macOS Sequoia"
 }
@@ -48,7 +48,7 @@ resource "jamfpro_computer_extension_attribute" "ea_stig_failed_count" {
   enabled                = true
   data_type              = "INTEGER"
   inventory_display_type = "EXTENSION_ATTRIBUTES"
-  script_contents        = file("${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_extension_attributes/compliance-FailedResultsCount.sh")
+  script_contents        = file("${path.module}/support_files/computer_extension_attributes/compliance-FailedResultsCount.sh")
 }
 
 resource "jamfpro_computer_extension_attribute" "ea_stig_failed_list" {
@@ -57,7 +57,7 @@ resource "jamfpro_computer_extension_attribute" "ea_stig_failed_list" {
   enabled                = true
   data_type              = "STRING"
   inventory_display_type = "EXTENSION_ATTRIBUTES"
-  script_contents        = file("${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_extension_attributes/compliance-FailedResultsList.sh")
+  script_contents        = file("${path.module}/support_files/computer_extension_attributes/compliance-FailedResultsList.sh")
 }
 
 resource "jamfpro_computer_extension_attribute" "ea_stig_version" {
@@ -66,7 +66,7 @@ resource "jamfpro_computer_extension_attribute" "ea_stig_version" {
   enabled                = true
   data_type              = "STRING"
   inventory_display_type = "EXTENSION_ATTRIBUTES"
-  script_contents        = file("${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_extension_attributes/compliance-version.sh")
+  script_contents        = file("${path.module}/support_files/computer_extension_attributes/compliance-version.sh")
 }
 
 ## Create Smart Computer Groups
@@ -302,26 +302,26 @@ resource "jamfpro_policy" "policy_sequoia_stig_remediation" {
 ## Define configuration profile details for Sonoma
 locals {
   sonoma_stig_dict = {
-    "Application Access"            = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sonoma_stig-applicationaccess.mobileconfig"
-    "Application Access Additional" = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sonoma_stig-applicationaccess.new.mobileconfig"
-    "Assistant"                     = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sonoma_stig-assistant.support.mobileconfig"
-    "Dock"                          = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sonoma_stig-dock.mobileconfig"
-    "Global Preferences"            = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sonoma_stig-GlobalPreferences.mobileconfig"
-    "iCloud"                        = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sonoma_stig-icloud.managed.mobileconfig"
-    "Login Window"                  = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sonoma_stig-loginwindow.mobileconfig"
-    "MCX"                           = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sonoma_stig-MCX.mobileconfig"
-    "MCX Bluetooth"                 = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sonoma_stig-MCXBluetooth.mobileconfig"
-    "mDNS Responder"                = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sonoma_stig-mDNSResponder.mobileconfig"
-    "Password Policy"               = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sonoma_stig-mobiledevice.passwordpolicy.mobileconfig"
-    "Sharing Preferences"           = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sonoma_stig-preferences.sharing.SharingPrefsExtension.mobileconfig"
-    "Screen Saver"                  = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sonoma_stig-screensaver.mobileconfig"
-    "Firewall"                      = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sonoma_stig-security.firewall.mobileconfig"
-    "Setup Assistant"               = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sonoma_stig-SetupAssistant.managed.mobileconfig"
-    "Software Update"               = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sonoma_stig-SoftwareUpdate.mobileconfig"
-    "Submit Diag Info"              = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sonoma_stig-SubmitDiagInfo.mobileconfig"
-    "System Policy Control"         = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sonoma_stig-systempolicy.control.mobileconfig"
-    "System Preferences"            = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sonoma_stig-systempreferences.mobileconfig"
-    "Managed Client"                = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sonoma_stig-timed.mobileconfig"
+    "Application Access"            = "${path.module}/support_files/computer_config_profiles/Sonoma_stig-applicationaccess.mobileconfig"
+    "Application Access Additional" = "${path.module}/support_files/computer_config_profiles/Sonoma_stig-applicationaccess.new.mobileconfig"
+    "Assistant"                     = "${path.module}/support_files/computer_config_profiles/Sonoma_stig-assistant.support.mobileconfig"
+    "Dock"                          = "${path.module}/support_files/computer_config_profiles/Sonoma_stig-dock.mobileconfig"
+    "Global Preferences"            = "${path.module}/support_files/computer_config_profiles/Sonoma_stig-GlobalPreferences.mobileconfig"
+    "iCloud"                        = "${path.module}/support_files/computer_config_profiles/Sonoma_stig-icloud.managed.mobileconfig"
+    "Login Window"                  = "${path.module}/support_files/computer_config_profiles/Sonoma_stig-loginwindow.mobileconfig"
+    "MCX"                           = "${path.module}/support_files/computer_config_profiles/Sonoma_stig-MCX.mobileconfig"
+    "MCX Bluetooth"                 = "${path.module}/support_files/computer_config_profiles/Sonoma_stig-MCXBluetooth.mobileconfig"
+    "mDNS Responder"                = "${path.module}/support_files/computer_config_profiles/Sonoma_stig-mDNSResponder.mobileconfig"
+    "Password Policy"               = "${path.module}/support_files/computer_config_profiles/Sonoma_stig-mobiledevice.passwordpolicy.mobileconfig"
+    "Sharing Preferences"           = "${path.module}/support_files/computer_config_profiles/Sonoma_stig-preferences.sharing.SharingPrefsExtension.mobileconfig"
+    "Screen Saver"                  = "${path.module}/support_files/computer_config_profiles/Sonoma_stig-screensaver.mobileconfig"
+    "Firewall"                      = "${path.module}/support_files/computer_config_profiles/Sonoma_stig-security.firewall.mobileconfig"
+    "Setup Assistant"               = "${path.module}/support_files/computer_config_profiles/Sonoma_stig-SetupAssistant.managed.mobileconfig"
+    "Software Update"               = "${path.module}/support_files/computer_config_profiles/Sonoma_stig-SoftwareUpdate.mobileconfig"
+    "Submit Diag Info"              = "${path.module}/support_files/computer_config_profiles/Sonoma_stig-SubmitDiagInfo.mobileconfig"
+    "System Policy Control"         = "${path.module}/support_files/computer_config_profiles/Sonoma_stig-systempolicy.control.mobileconfig"
+    "System Preferences"            = "${path.module}/support_files/computer_config_profiles/Sonoma_stig-systempreferences.mobileconfig"
+    "Managed Client"                = "${path.module}/support_files/computer_config_profiles/Sonoma_stig-timed.mobileconfig"
   }
 }
 
@@ -350,7 +350,7 @@ resource "jamfpro_macos_configuration_profile_plist" "sonoma_stig_smart_card" {
   category_id         = jamfpro_category.category_sonoma_stig_benchmarks.id
   level               = "System"
 
-  payloads         = file("${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sonoma_stig-security.smartcard.mobileconfig")
+  payloads         = file("${path.module}/support_files/computer_config_profiles/Sonoma_stig-security.smartcard.mobileconfig")
   payload_validate = false
 
   scope {
@@ -362,25 +362,25 @@ resource "jamfpro_macos_configuration_profile_plist" "sonoma_stig_smart_card" {
 ## Define configuration profile details for Sequoia part 1
 locals {
   sequoia_stig_dict = {
-    "Application Access"            = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sequoia_stig-applicationaccess.mobileconfig"
-    "Application Access Additional" = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sequoia_stig-applicationaccess.new.mobileconfig"
-    "Assistant"                     = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sequoia_stig-assistant.support.mobileconfig"
-    "Dock"                          = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sequoia_stig-dock.mobileconfig"
-    "Global Preferences"            = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sequoia_stig-GlobalPreferences.mobileconfig"
-    "iCloud"                        = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sequoia_stig-icloud.managed.mobileconfig"
-    "Login Window"                  = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sequoia_stig-loginwindow.mobileconfig"
-    "MCX"                           = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sequoia_stig-MCX.mobileconfig"
-    "MCX Bluetooth"                 = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sequoia_stig-MCXBluetooth.mobileconfig"
-    "mDNS Responder"                = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sequoia_stig-mDNSResponder.mobileconfig"
-    "Password Policy"               = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sequoia_stig-mobiledevice.passwordpolicy.mobileconfig"
-    "Screen Saver"                  = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sequoia_stig-screensaver.mobileconfig"
-    "Firewall"                      = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sequoia_stig-security.firewall.mobileconfig"
-    "Setup Assistant"               = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sequoia_stig-SetupAssistant.managed.mobileconfig"
-    "Software Update"               = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sequoia_stig-SoftwareUpdate.mobileconfig"
-    "Submit Diag Info"              = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sequoia_stig-SubmitDiagInfo.mobileconfig"
-    "System Policy Control"         = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sequoia_stig-systempolicy.control.mobileconfig"
-    "System Preferences"            = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sequoia_stig-systempreferences.mobileconfig"
-    "Managed Client"                = "${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sequoia_stig-timed.mobileconfig"
+    "Application Access"            = "${path.module}/support_files/computer_config_profiles/Sequoia_stig-applicationaccess.mobileconfig"
+    "Application Access Additional" = "${path.module}/support_files/computer_config_profiles/Sequoia_stig-applicationaccess.new.mobileconfig"
+    "Assistant"                     = "${path.module}/support_files/computer_config_profiles/Sequoia_stig-assistant.support.mobileconfig"
+    "Dock"                          = "${path.module}/support_files/computer_config_profiles/Sequoia_stig-dock.mobileconfig"
+    "Global Preferences"            = "${path.module}/support_files/computer_config_profiles/Sequoia_stig-GlobalPreferences.mobileconfig"
+    "iCloud"                        = "${path.module}/support_files/computer_config_profiles/Sequoia_stig-icloud.managed.mobileconfig"
+    "Login Window"                  = "${path.module}/support_files/computer_config_profiles/Sequoia_stig-loginwindow.mobileconfig"
+    "MCX"                           = "${path.module}/support_files/computer_config_profiles/Sequoia_stig-MCX.mobileconfig"
+    "MCX Bluetooth"                 = "${path.module}/support_files/computer_config_profiles/Sequoia_stig-MCXBluetooth.mobileconfig"
+    "mDNS Responder"                = "${path.module}/support_files/computer_config_profiles/Sequoia_stig-mDNSResponder.mobileconfig"
+    "Password Policy"               = "${path.module}/support_files/computer_config_profiles/Sequoia_stig-mobiledevice.passwordpolicy.mobileconfig"
+    "Screen Saver"                  = "${path.module}/support_files/computer_config_profiles/Sequoia_stig-screensaver.mobileconfig"
+    "Firewall"                      = "${path.module}/support_files/computer_config_profiles/Sequoia_stig-security.firewall.mobileconfig"
+    "Setup Assistant"               = "${path.module}/support_files/computer_config_profiles/Sequoia_stig-SetupAssistant.managed.mobileconfig"
+    "Software Update"               = "${path.module}/support_files/computer_config_profiles/Sequoia_stig-SoftwareUpdate.mobileconfig"
+    "Submit Diag Info"              = "${path.module}/support_files/computer_config_profiles/Sequoia_stig-SubmitDiagInfo.mobileconfig"
+    "System Policy Control"         = "${path.module}/support_files/computer_config_profiles/Sequoia_stig-systempolicy.control.mobileconfig"
+    "System Preferences"            = "${path.module}/support_files/computer_config_profiles/Sequoia_stig-systempreferences.mobileconfig"
+    "Managed Client"                = "${path.module}/support_files/computer_config_profiles/Sequoia_stig-timed.mobileconfig"
   }
 }
 
@@ -410,7 +410,7 @@ resource "jamfpro_macos_configuration_profile_plist" "sequoia_stig_smart_card" {
   category_id         = jamfpro_category.category_sequoia_stig_benchmarks.id
   level               = "System"
 
-  payloads         = file("${var.support_files_path_prefix}modules/compliance-macOS-disa-stig/support_files/computer_config_profiles/Sequoia_stig-security.smartcard.mobileconfig")
+  payloads         = file("${path.module}/support_files/computer_config_profiles/Sequoia_stig-security.smartcard.mobileconfig")
   payload_validate = false
 
   scope {

--- a/modules/compliance-macOS-nist-800-171/main.tf
+++ b/modules/compliance-macOS-nist-800-171/main.tf
@@ -28,7 +28,7 @@ resource "jamfpro_category" "category_sequoia_800_171_benchmarks" {
 resource "jamfpro_script" "script_sonoma_800_171_compliance" {
   name            = "Sonoma - NIST 800-171 Compliance [${random_integer.entropy.result}]"
   priority        = "AFTER"
-  script_contents = file("${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_scripts/sonoma_800-171_compliance.sh")
+  script_contents = file("${path.module}/support_files/computer_scripts/sonoma_800-171_compliance.sh")
   category_id     = jamfpro_category.category_sonoma_800_171_benchmarks.id
   info            = "This script will apply a set of rules related to the NIST 800-171 benchmark for macOS Sonoma"
 }
@@ -36,7 +36,7 @@ resource "jamfpro_script" "script_sonoma_800_171_compliance" {
 resource "jamfpro_script" "script_sequoia_800_171_compliance" {
   name            = "Sequoia - NIST 800-171 Compliance [${random_integer.entropy.result}]"
   priority        = "AFTER"
-  script_contents = file("${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_scripts/sequoia_800-171_compliance.sh")
+  script_contents = file("${path.module}/support_files/computer_scripts/sequoia_800-171_compliance.sh")
   category_id     = jamfpro_category.category_sequoia_800_171_benchmarks.id
   info            = "This script will apply a set of rules related to the NIST 800-171 benchmark for macOS Sequoia"
 }
@@ -48,7 +48,7 @@ resource "jamfpro_computer_extension_attribute" "ea_800_171_failed_count" {
   enabled                = true
   data_type              = "INTEGER"
   inventory_display_type = "EXTENSION_ATTRIBUTES"
-  script_contents        = file("${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_extension_attributes/compliance-FailedResultsCount.sh")
+  script_contents        = file("${path.module}/support_files/computer_extension_attributes/compliance-FailedResultsCount.sh")
 }
 
 resource "jamfpro_computer_extension_attribute" "ea_800_171_failed_list" {
@@ -57,7 +57,7 @@ resource "jamfpro_computer_extension_attribute" "ea_800_171_failed_list" {
   enabled                = true
   data_type              = "STRING"
   inventory_display_type = "EXTENSION_ATTRIBUTES"
-  script_contents        = file("${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_extension_attributes/compliance-FailedResultsList.sh")
+  script_contents        = file("${path.module}/support_files/computer_extension_attributes/compliance-FailedResultsList.sh")
 }
 
 resource "jamfpro_computer_extension_attribute" "ea_800_171_version" {
@@ -66,7 +66,7 @@ resource "jamfpro_computer_extension_attribute" "ea_800_171_version" {
   enabled                = true
   data_type              = "STRING"
   inventory_display_type = "EXTENSION_ATTRIBUTES"
-  script_contents        = file("${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_extension_attributes/compliance-version.sh")
+  script_contents        = file("${path.module}/support_files/computer_extension_attributes/compliance-version.sh")
 }
 
 ## Create Smart Computer Groups
@@ -302,29 +302,29 @@ resource "jamfpro_policy" "policy_sequoia_800_171_remediation" {
 ## Define configuration profile details for Sonoma
 locals {
   sonoma_800_171_dict = {
-    "Application Access"    = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sonoma_800-171-applicationaccess.mobileconfig"
-    "Assistant Support"     = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sonoma_800-171-assistant.support.mobileconfig"
-    "Disc Recording"        = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sonoma_800-171-DiscRecording.mobileconfig"
-    "Dock"                  = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sonoma_800-171-dock.mobileconfig"
-    "Apple IR Controller"   = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sonoma_800-171-driver.AppleIRController.mobileconfig"
-    "Finder"                = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sonoma_800-171-finder.mobileconfig"
-    "Global Preferences"    = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sonoma_800-171-GlobalPreferences.mobileconfig"
-    "iCloud"                = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sonoma_800-171-icloud.managed.mobileconfig"
-    "Login Window"          = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sonoma_800-171-loginwindow.mobileconfig"
-    "MCX"                   = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sonoma_800-171-MCX.mobileconfig"
-    "MCX Bluetooth"         = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sonoma_800-171-MCXBluetooth.mobileconfig"
-    "mDNS Responder"        = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sonoma_800-171-mDNSResponder.mobileconfig"
-    "Password Policy"       = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sonoma_800-171-mobiledevice.passwordpolicy.mobileconfig"
-    "Sharing Preferences"   = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sonoma_800-171-preferences.sharing.SharingPrefsExtension.mobileconfig"
-    "Screen Saver"          = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sonoma_800-171-screensaver.mobileconfig"
-    "Firewall"              = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sonoma_800-171-security.firewall.mobileconfig"
-    "Security"              = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sonoma_800-171-security.mobileconfig"
-    "Setup Assistant"       = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sonoma_800-171-SetupAssistant.managed.mobileconfig"
-    "Submit Diag Info"      = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sonoma_800-171-SubmitDiagInfo.mobileconfig"
-    "System Policy Control" = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sonoma_800-171-systempolicy.control.mobileconfig"
-    "Managed System Policy" = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sonoma_800-171-systempolicy.managed.mobileconfig"
-    "System Preferences"    = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sonoma_800-171-systempreferences.mobileconfig"
-    "Managed Client"        = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sonoma_800-171-timed.mobileconfig"
+    "Application Access"    = "${path.module}/support_files/computer_config_profiles/Sonoma_800-171-applicationaccess.mobileconfig"
+    "Assistant Support"     = "${path.module}/support_files/computer_config_profiles/Sonoma_800-171-assistant.support.mobileconfig"
+    "Disc Recording"        = "${path.module}/support_files/computer_config_profiles/Sonoma_800-171-DiscRecording.mobileconfig"
+    "Dock"                  = "${path.module}/support_files/computer_config_profiles/Sonoma_800-171-dock.mobileconfig"
+    "Apple IR Controller"   = "${path.module}/support_files/computer_config_profiles/Sonoma_800-171-driver.AppleIRController.mobileconfig"
+    "Finder"                = "${path.module}/support_files/computer_config_profiles/Sonoma_800-171-finder.mobileconfig"
+    "Global Preferences"    = "${path.module}/support_files/computer_config_profiles/Sonoma_800-171-GlobalPreferences.mobileconfig"
+    "iCloud"                = "${path.module}/support_files/computer_config_profiles/Sonoma_800-171-icloud.managed.mobileconfig"
+    "Login Window"          = "${path.module}/support_files/computer_config_profiles/Sonoma_800-171-loginwindow.mobileconfig"
+    "MCX"                   = "${path.module}/support_files/computer_config_profiles/Sonoma_800-171-MCX.mobileconfig"
+    "MCX Bluetooth"         = "${path.module}/support_files/computer_config_profiles/Sonoma_800-171-MCXBluetooth.mobileconfig"
+    "mDNS Responder"        = "${path.module}/support_files/computer_config_profiles/Sonoma_800-171-mDNSResponder.mobileconfig"
+    "Password Policy"       = "${path.module}/support_files/computer_config_profiles/Sonoma_800-171-mobiledevice.passwordpolicy.mobileconfig"
+    "Sharing Preferences"   = "${path.module}/support_files/computer_config_profiles/Sonoma_800-171-preferences.sharing.SharingPrefsExtension.mobileconfig"
+    "Screen Saver"          = "${path.module}/support_files/computer_config_profiles/Sonoma_800-171-screensaver.mobileconfig"
+    "Firewall"              = "${path.module}/support_files/computer_config_profiles/Sonoma_800-171-security.firewall.mobileconfig"
+    "Security"              = "${path.module}/support_files/computer_config_profiles/Sonoma_800-171-security.mobileconfig"
+    "Setup Assistant"       = "${path.module}/support_files/computer_config_profiles/Sonoma_800-171-SetupAssistant.managed.mobileconfig"
+    "Submit Diag Info"      = "${path.module}/support_files/computer_config_profiles/Sonoma_800-171-SubmitDiagInfo.mobileconfig"
+    "System Policy Control" = "${path.module}/support_files/computer_config_profiles/Sonoma_800-171-systempolicy.control.mobileconfig"
+    "Managed System Policy" = "${path.module}/support_files/computer_config_profiles/Sonoma_800-171-systempolicy.managed.mobileconfig"
+    "System Preferences"    = "${path.module}/support_files/computer_config_profiles/Sonoma_800-171-systempreferences.mobileconfig"
+    "Managed Client"        = "${path.module}/support_files/computer_config_profiles/Sonoma_800-171-timed.mobileconfig"
   }
 }
 
@@ -353,7 +353,7 @@ resource "jamfpro_macos_configuration_profile_plist" "sonoma_800_171_smart_card"
   category_id         = jamfpro_category.category_sonoma_800_171_benchmarks.id
   level               = "System"
 
-  payloads         = file("${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sonoma_800-171-security.smartcard.mobileconfig")
+  payloads         = file("${path.module}/support_files/computer_config_profiles/Sonoma_800-171-security.smartcard.mobileconfig")
   payload_validate = false
 
   scope {
@@ -365,28 +365,28 @@ resource "jamfpro_macos_configuration_profile_plist" "sonoma_800_171_smart_card"
 ## Define configuration profile details for Sequoia part 1
 locals {
   sequoia_800_171_dict = {
-    "Accessibility"         = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sequoia_800-171-Accessibility.mobileconfig"
-    "Application Access"    = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sequoia_800-171-applicationaccess.mobileconfig"
-    "Assistant Support"     = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sequoia_800-171-assistant.support.mobileconfig"
-    "Disc Recording"        = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sequoia_800-171-DiscRecording.mobileconfig"
-    "Dock"                  = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sequoia_800-171-dock.mobileconfig"
-    "Apple IR Controller"   = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sequoia_800-171-driver.AppleIRController.mobileconfig"
-    "Finder"                = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sequoia_800-171-finder.mobileconfig"
-    "Global Preferences"    = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sequoia_800-171-GlobalPreferences.mobileconfig"
-    "iCloud"                = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sequoia_800-171-icloud.managed.mobileconfig"
-    "Login Window"          = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sequoia_800-171-loginwindow.mobileconfig"
-    "MCX"                   = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sequoia_800-171-MCX.mobileconfig"
-    "MCX Bluetooth"         = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sequoia_800-171-MCXBluetooth.mobileconfig"
-    "mDNS Responder"        = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sequoia_800-171-mDNSResponder.mobileconfig"
-    "Password Policy"       = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sequoia_800-171-mobiledevice.passwordpolicy.mobileconfig"
-    "Screen Saver"          = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sequoia_800-171-screensaver.mobileconfig"
-    "Firewall"              = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sequoia_800-171-security.firewall.mobileconfig"
-    "Setup Assistant"       = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sequoia_800-171-SetupAssistant.managed.mobileconfig"
-    "Submit Diag Info"      = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sequoia_800-171-SubmitDiagInfo.mobileconfig"
-    "System Policy Control" = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sequoia_800-171-systempolicy.control.mobileconfig"
-    "Managed System Policy" = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sequoia_800-171-systempolicy.managed.mobileconfig"
-    "System Preferences"    = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sequoia_800-171-systempreferences.mobileconfig"
-    "Managed Client"        = "${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sequoia_800-171-timed.mobileconfig"
+    "Accessibility"         = "${path.module}/support_files/computer_config_profiles/Sequoia_800-171-Accessibility.mobileconfig"
+    "Application Access"    = "${path.module}/support_files/computer_config_profiles/Sequoia_800-171-applicationaccess.mobileconfig"
+    "Assistant Support"     = "${path.module}/support_files/computer_config_profiles/Sequoia_800-171-assistant.support.mobileconfig"
+    "Disc Recording"        = "${path.module}/support_files/computer_config_profiles/Sequoia_800-171-DiscRecording.mobileconfig"
+    "Dock"                  = "${path.module}/support_files/computer_config_profiles/Sequoia_800-171-dock.mobileconfig"
+    "Apple IR Controller"   = "${path.module}/support_files/computer_config_profiles/Sequoia_800-171-driver.AppleIRController.mobileconfig"
+    "Finder"                = "${path.module}/support_files/computer_config_profiles/Sequoia_800-171-finder.mobileconfig"
+    "Global Preferences"    = "${path.module}/support_files/computer_config_profiles/Sequoia_800-171-GlobalPreferences.mobileconfig"
+    "iCloud"                = "${path.module}/support_files/computer_config_profiles/Sequoia_800-171-icloud.managed.mobileconfig"
+    "Login Window"          = "${path.module}/support_files/computer_config_profiles/Sequoia_800-171-loginwindow.mobileconfig"
+    "MCX"                   = "${path.module}/support_files/computer_config_profiles/Sequoia_800-171-MCX.mobileconfig"
+    "MCX Bluetooth"         = "${path.module}/support_files/computer_config_profiles/Sequoia_800-171-MCXBluetooth.mobileconfig"
+    "mDNS Responder"        = "${path.module}/support_files/computer_config_profiles/Sequoia_800-171-mDNSResponder.mobileconfig"
+    "Password Policy"       = "${path.module}/support_files/computer_config_profiles/Sequoia_800-171-mobiledevice.passwordpolicy.mobileconfig"
+    "Screen Saver"          = "${path.module}/support_files/computer_config_profiles/Sequoia_800-171-screensaver.mobileconfig"
+    "Firewall"              = "${path.module}/support_files/computer_config_profiles/Sequoia_800-171-security.firewall.mobileconfig"
+    "Setup Assistant"       = "${path.module}/support_files/computer_config_profiles/Sequoia_800-171-SetupAssistant.managed.mobileconfig"
+    "Submit Diag Info"      = "${path.module}/support_files/computer_config_profiles/Sequoia_800-171-SubmitDiagInfo.mobileconfig"
+    "System Policy Control" = "${path.module}/support_files/computer_config_profiles/Sequoia_800-171-systempolicy.control.mobileconfig"
+    "Managed System Policy" = "${path.module}/support_files/computer_config_profiles/Sequoia_800-171-systempolicy.managed.mobileconfig"
+    "System Preferences"    = "${path.module}/support_files/computer_config_profiles/Sequoia_800-171-systempreferences.mobileconfig"
+    "Managed Client"        = "${path.module}/support_files/computer_config_profiles/Sequoia_800-171-timed.mobileconfig"
   }
 }
 
@@ -416,7 +416,7 @@ resource "jamfpro_macos_configuration_profile_plist" "sequoia_800_171_smart_card
   category_id         = jamfpro_category.category_sequoia_800_171_benchmarks.id
   level               = "System"
 
-  payloads         = file("${var.support_files_path_prefix}modules/compliance-macOS-nist-800-171/support_files/computer_config_profiles/Sequoia_800-171-security.smartcard.mobileconfig")
+  payloads         = file("${path.module}/support_files/computer_config_profiles/Sequoia_800-171-security.smartcard.mobileconfig")
   payload_validate = false
 
   scope {

--- a/modules/management-iOS-configuration-profiles/main.tf
+++ b/modules/management-iOS-configuration-profiles/main.tf
@@ -42,7 +42,7 @@ resource "jamfpro_mobile_device_configuration_profile_plist" "mobile_device_conf
   level              = "Device Level"
   category_id        = jamfpro_category.category_restrictions.id
   redeploy_on_update = "Newly Assigned"
-  payloads           = file("${var.support_files_path_prefix}modules/management-iOS-configuration-profiles/support_files/restrict_appleid_changes.mobileconfig")
+  payloads           = file("${path.module}/support_files/restrict_appleid_changes.mobileconfig")
 
   scope {
     all_mobile_devices = false
@@ -56,7 +56,7 @@ resource "jamfpro_mobile_device_configuration_profile_plist" "mobile_device_conf
   level              = "Device Level"
   category_id        = jamfpro_category.category_restrictions.id
   redeploy_on_update = "Newly Assigned"
-  payloads           = file("${var.support_files_path_prefix}modules/management-iOS-configuration-profiles/support_files/restrict_airdrop.mobileconfig")
+  payloads           = file("${path.module}/support_files/restrict_airdrop.mobileconfig")
 
   scope {
     all_mobile_devices = false
@@ -70,7 +70,7 @@ resource "jamfpro_mobile_device_configuration_profile_plist" "mobile_device_conf
   level              = "Device Level"
   category_id        = jamfpro_category.category_demo.id
   redeploy_on_update = "Newly Assigned"
-  payloads           = file("${var.support_files_path_prefix}modules/management-iOS-configuration-profiles/support_files/passcode_requirements.mobileconfig")
+  payloads           = file("${path.module}/support_files/passcode_requirements.mobileconfig")
 
   scope {
     all_mobile_devices = false
@@ -84,7 +84,7 @@ resource "jamfpro_mobile_device_configuration_profile_plist" "mobile_device_conf
   level              = "Device Level"
   category_id        = jamfpro_category.category_restrictions.id
   redeploy_on_update = "Newly Assigned"
-  payloads           = file("${var.support_files_path_prefix}modules/management-iOS-configuration-profiles/support_files/restrict_erase_content_and_settings.mobileconfig")
+  payloads           = file("${path.module}/support_files/restrict_erase_content_and_settings.mobileconfig")
 
   scope {
     all_mobile_devices = false
@@ -98,7 +98,7 @@ resource "jamfpro_mobile_device_configuration_profile_plist" "mobile_device_conf
   level              = "Device Level"
   category_id        = jamfpro_category.category_restrictions.id
   redeploy_on_update = "Newly Assigned"
-  payloads           = file("${var.support_files_path_prefix}modules/management-iOS-configuration-profiles/support_files/restrict_camera.mobileconfig")
+  payloads           = file("${path.module}/support_files/restrict_camera.mobileconfig")
 
   scope {
     all_mobile_devices = false
@@ -112,7 +112,7 @@ resource "jamfpro_mobile_device_configuration_profile_plist" "mobile_device_conf
   level              = "Device Level"
   category_id        = jamfpro_category.category_restrictions.id
   redeploy_on_update = "Newly Assigned"
-  payloads           = file("${var.support_files_path_prefix}modules/management-iOS-configuration-profiles/support_files/restrict_screenshots.mobileconfig")
+  payloads           = file("${path.module}/support_files/restrict_screenshots.mobileconfig")
 
   scope {
     all_mobile_devices = false
@@ -126,7 +126,7 @@ resource "jamfpro_mobile_device_configuration_profile_plist" "mobile_device_conf
   level              = "Device Level"
   category_id        = jamfpro_category.category_demo.id
   redeploy_on_update = "Newly Assigned"
-  payloads           = file("${var.support_files_path_prefix}modules/management-iOS-configuration-profiles/support_files/user_enrollment_byod_restrictions.mobileconfig")
+  payloads           = file("${path.module}/support_files/user_enrollment_byod_restrictions.mobileconfig")
 
   scope {
     all_mobile_devices = false
@@ -183,7 +183,7 @@ resource "jamfpro_mobile_device_configuration_profile_plist" "mobile_device_conf
   level              = "Device Level"
   category_id        = jamfpro_category.category_demo.id
   redeploy_on_update = "Newly Assigned"
-  payloads           = file("${var.support_files_path_prefix}modules/management-iOS-configuration-profiles/support_files/kiosk_mode_safari_single_app_mode.mobileconfig")
+  payloads           = file("${path.module}/support_files/kiosk_mode_safari_single_app_mode.mobileconfig")
 
   scope {
     all_mobile_devices      = false
@@ -198,7 +198,7 @@ resource "jamfpro_mobile_device_configuration_profile_plist" "mobile_device_conf
   level              = "Device Level"
   category_id        = jamfpro_category.category_demo.id
   redeploy_on_update = "Newly Assigned"
-  payloads           = file("${var.support_files_path_prefix}modules/management-iOS-configuration-profiles/support_files/shared_device_restrictions.mobileconfig")
+  payloads           = file("${path.module}/support_files/shared_device_restrictions.mobileconfig")
 
   scope {
     all_mobile_devices      = false

--- a/modules/management-macOS-SSOe-Okta/main.tf
+++ b/modules/management-macOS-SSOe-Okta/main.tf
@@ -23,7 +23,7 @@ resource "jamfpro_category" "category_ssoe" {
 resource "jamfpro_script" "script_ssoe-okta" {
   name            = "SSOe-(Okta) [${random_integer.entropy.result}]"
   priority        = "AFTER"
-  script_contents = file("${var.support_files_path_prefix}modules/management-macOS-SSOe-Okta/support_files/computer_scripts/SSOe-(Okta).zsh")
+  script_contents = file("${path.module}/support_files/computer_scripts/SSOe-(Okta).zsh")
   category_id     = jamfpro_category.category_ssoe.id
   info            = "This script will check for the presence of the Okta Verify App. If not present, it will download and install the latest version. It will then launch the app with the the URL of the Experience Jamf Okta tenant."
 }
@@ -50,7 +50,7 @@ resource "jamfpro_smart_computer_group" "ssoe-okta" {
 ## Define configuration profiles
 locals {
   ssoe-okta_dict = {
-    "SSOe-Okta" = "${var.support_files_path_prefix}modules/management-macOS-SSOe-Okta/support_files/computer_config_profiles/SSOe-(Okta).mobileconfig"
+    "SSOe-Okta" = "${path.module}/support_files/computer_config_profiles/SSOe-(Okta).mobileconfig"
   }
 }
 

--- a/modules/onboarder-all/main.tf
+++ b/modules/onboarder-all/main.tf
@@ -13,28 +13,23 @@ terraform {
 }
 
 module "onboarder-management-macOS" {
-  source                    = "../onboarder-management-macOS"
-  support_files_path_prefix = var.support_files_path_prefix
+  source = "../onboarder-management-macOS"
 }
 
 module "onboarder-management-mobile" {
-  source                    = "../onboarder-management-mobile"
-  support_files_path_prefix = var.support_files_path_prefix
+  source = "../onboarder-management-mobile"
 }
 
 module "onboarder-app-installers" {
-  source                    = "../onboarder-app-installers"
-  support_files_path_prefix = var.support_files_path_prefix
+  source = "../onboarder-app-installers"
 }
 
 module "compliance-macOS-cis-level-1" {
-  source                    = "../compliance-macOS-cis-level-1"
-  support_files_path_prefix = var.support_files_path_prefix
+  source = "../compliance-macOS-cis-level-1"
 }
 
 module "compliance-iOS-cis-level-1" {
-  source                    = "../compliance-iOS-cis-level-1"
-  support_files_path_prefix = var.support_files_path_prefix
+  source = "../compliance-iOS-cis-level-1"
 }
 
 module "configuration-jamf-security-cloud-all-services" {

--- a/modules/onboarder-management-mobile/main.tf
+++ b/modules/onboarder-management-mobile/main.tf
@@ -9,6 +9,5 @@ terraform {
 }
 
 module "management-iOS-configuration-profiles" {
-  source                    = "../management-iOS-configuration-profiles"
-  support_files_path_prefix = var.support_files_path_prefix
+  source = "../management-iOS-configuration-profiles"
 }

--- a/spec.yml
+++ b/spec.yml
@@ -125,6 +125,14 @@ options:
     display_name: Enable Customizable Block Pages
     display_desc: Configures block pages for content filtering. Block pages can be further customized with company/organization branding.
 
+  - key: include_filevault
+    type: <boolean>
+    presence: optional
+    module_name: module.endpoint-security-macOS-filevault
+    category: Security
+    display_name: Enforce & Escrow FileVault 2
+    display_desc: For managed computers, configure the necessary capabilities including Configuration Profile, Script, and Policy to enable and enforce FileVault 2 and make certain that the recovery key is escrowed by Jamf.
+
   ## Jamf Protect Onboarder Modules
   - key: include_jamf_protect_trial_kickstart
     type: <boolean>


### PR DESCRIPTION
# Change

**_File prefix fix and spec update_**

- Changed all legacy support_files_path_prefix variable usage to the more modern and supported path.module
- Updated spec.yml to reflect FileVault module for Onboarder GUI

## Type of Change

- [x] Refactor (refactoring code, removing code, changing code structure)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] For module changes - I have included an example in the /examples directory and a README.md in the module root
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated spec.yaml as appropriate
- [x] I have checked `Terraform Init` and `Terraform Fmt`
- [x] I have ran `Terraform Apply` against any active module changes
