### PR TITLE
Admin SSO Module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -119,6 +119,14 @@ module "compliance-macOS-cmmc-level-1" {
   jamfpro_client_secret = var.jamfpro_client_secret
 }
 
+module "configuration-jamf-pro-admin-sso" {
+  count                 = var.include_jamf_pro_admin_sso == true ? 1 : 0
+  source                = "./modules/configuration-jamf-pro-admin-sso"
+  jamfpro_instance_url  = var.jamfpro_instance_url
+  jamfpro_client_id     = var.jamfpro_client_id
+  jamfpro_client_secret = var.jamfpro_client_secret
+}
+
 module "configuration-jamf-pro-smart-groups" {
   count                 = var.include_qol_smart_groups == true ? 1 : 0
   source                = "./modules/configuration-jamf-pro-smart-groups"

--- a/modules/configuration-jamf-pro-admin-sso/adminssoconfigure.sh
+++ b/modules/configuration-jamf-pro-admin-sso/adminssoconfigure.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+jamfpro_instance_url="$1"
+jamfpro_client_id="$2"
+jamfpro_client_secret="$3"
+
+# Obtain the bearer token
+response=$(curl --silent --location --request POST "${jamfpro_instance_url}/api/oauth/token" \
+  --header "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "client_id=${jamfpro_client_id}" \
+  --data-urlencode "grant_type=client_credentials" \
+  --data-urlencode "client_secret=${jamfpro_client_secret}")
+access_token=$(echo "$response" | awk -F'"' '/"access_token":/ {print $4}')
+
+# Check if token was retrieved successfully
+if [ -z "$access_token" ] || [ "$access_token" == "null" ]; then
+  echo "Failed to obtain bearer token. Exiting."
+  exit 1
+fi
+
+# Make the API request using the token
+response=$(curl --silent --location --request PUT "${jamfpro_instance_url}/api/v3/sso" \
+  --header "accept: application/json" \
+  --header "content-type: application/json" \
+  --header "Authorization: Bearer $access_token" \
+  --data ' {
+  "configurationType": "OIDC",
+  "oidcSettings": {
+    "userMapping": "EMAIL"
+  },
+  "samlSettings": {
+    "tokenExpirationDisabled": false,
+    "userAttributeEnabled": false,
+    "userAttributeName": " ",
+    "groupAttributeName": "http://schemas.xmlsoap.org/claims/Group",
+    "groupRdnKey": " ",
+    "otherProviderTypeName": " ",
+    "sessionTimeout": 480
+  },
+  "ssoForEnrollmentEnabled": false,
+  "ssoBypassAllowed": false,
+  "ssoEnabled": true,
+  "ssoForMacOsSelfServiceEnabled": false,
+  "enrollmentSsoForAccountDrivenEnrollmentEnabled": false,
+  "groupEnrollmentAccessEnabled": false,
+  "groupEnrollmentAccessName": " "
+}')

--- a/modules/configuration-jamf-pro-admin-sso/adminssodelete.sh
+++ b/modules/configuration-jamf-pro-admin-sso/adminssodelete.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+jamfpro_instance_url="$1"
+jamfpro_client_id="$2"
+jamfpro_client_secret="$3"
+
+# Obtain the bearer token
+response=$(curl --silent --location --request POST "${jamfpro_instance_url}/api/oauth/token" \
+  --header "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "client_id=${jamfpro_client_id}" \
+  --data-urlencode "grant_type=client_credentials" \
+  --data-urlencode "client_secret=${jamfpro_client_secret}")
+access_token=$(echo "$response" | awk -F'"' '/"access_token":/ {print $4}')
+
+# Check if token was retrieved successfully
+if [ -z "$access_token" ] || [ "$access_token" == "null" ]; then
+  echo "Failed to obtain bearer token. Exiting."
+  exit 1
+fi
+
+# Make the API request using the token
+response=$(curl --silent --location --request POST "${jamfpro_instance_url}/api/v3/sso/disable" \
+  --header "accept: application/json" \
+  --header "content-type: application/json" \
+  --header "Authorization: Bearer $access_token")

--- a/modules/configuration-jamf-pro-admin-sso/main.tf
+++ b/modules/configuration-jamf-pro-admin-sso/main.tf
@@ -1,0 +1,28 @@
+## Call Terraform provider
+terraform {
+  required_providers {
+    jamfpro = {
+      source  = "deploymenttheory/jamfpro"
+      version = ">= 0.1.5"
+    }
+  }
+}
+
+# Define a resource to use the local-exec provisioner
+resource "null_resource" "run_script" {
+
+  triggers = {
+    jamfpro_instance_url  = var.jamfpro_instance_url
+    jamfpro_client_id     = var.jamfpro_client_id
+    jamfpro_client_secret = var.jamfpro_client_secret
+  }
+  provisioner "local-exec" {
+    command = "${path.module}/adminssoconfigure.sh ${var.jamfpro_instance_url} ${var.jamfpro_client_id} ${var.jamfpro_client_secret}"
+    when    = create
+  }
+
+  provisioner "local-exec" {
+    command = "${path.module}/adminssodelete.sh ${self.triggers.jamfpro_instance_url} ${self.triggers.jamfpro_client_id} ${self.triggers.jamfpro_client_secret}"
+    when    = destroy
+  }
+}

--- a/modules/configuration-jamf-pro-admin-sso/variables.tf
+++ b/modules/configuration-jamf-pro-admin-sso/variables.tf
@@ -1,0 +1,43 @@
+variable "jamfpro_instance_url" {
+  description = "Jamf Pro URL name."
+  type        = string
+  default     = ""
+}
+
+variable "jamfpro_client_id" {
+  description = "Jamf Pro Client ID for authentication."
+  type        = string
+  default     = ""
+}
+
+variable "jamfpro_client_secret" {
+  description = "Jamf Pro Client Secret for authentication."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "jamfprotect_url" {
+  description = "Jamf Protect URL name."
+  type        = string
+  default     = ""
+}
+
+variable "jamfprotect_clientID" {
+  description = "Jamf Protect Client ID for authentication."
+  type        = string
+  default     = ""
+}
+
+variable "jamfprotect_client_password" {
+  description = "Jamf Protect Client passwrd for authentication."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "jamfpro_auth_method" {
+  description = "Jamf Pro Auth Method."
+  type        = string
+  default     = "oauth2" #basic or oauth2
+}

--- a/variables.tf
+++ b/variables.tf
@@ -435,6 +435,10 @@ variable "include_computer_management_settings" {
   default = false
 }
 
+variable "include_jamf_pro_admin_sso" {
+  type    = bool
+  default = false
+}
 
 variable "include_mobile_device_kickstart" {
   type    = bool


### PR DESCRIPTION
# Change

**_Admin SSO_**

The configuration-jamf-pro-admin-sso module now can either check or uncheck the Admin SSO box which is a required setting for all micro service enabled features of Jamf Pro (Blueprints, Compliance Benchmarks, and Scheduled OS Updates)

## Type of Change

- [X] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] For module changes - I have included an example in the /examples directory and a README.md in the module root
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated spec.yaml as appropriate
- [x] I have checked `Terraform Init` and `Terraform Fmt`
- [x] I have ran `Terraform Apply` against any active module changes
