### PR TITLE
No default for Pro credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Terraform configuration for the Jamf Platform.
 
 Provider versions used in this release:
 
-- deploymenttheory/jamfpro > = v0.11.0
+- deploymenttheory/jamfpro = v0.19.1
 - danjamf/jsctfprovider >= v0.0.23
 - hasicorp/aws v55.62.0 (optional with SaaS tenancy control)
 
-This project utlizes the unoffical Terraform providers for [Jamf Pro](https://registry.terraform.io/providers/deploymenttheory/jamfpro/latest) and [Jamf Security Cloud](https://registry.terraform.io/providers/danjamf/jsctfprovider/latest)
+This project utlizes the community Terraform providers for [Jamf Pro](https://registry.terraform.io/providers/deploymenttheory/jamfpro/latest) and [Jamf Security Cloud](https://registry.terraform.io/providers/danjamf/jsctfprovider/latest)
 
 ## Parallelism and API delay
 

--- a/variables.tf
+++ b/variables.tf
@@ -2,7 +2,6 @@
 variable "jamfpro_instance_url" {
   description = "Jamf Pro Instance name."
   type        = string
-  default     = ""
 }
 
 variable "jamfpro_auth_method" {
@@ -14,14 +13,12 @@ variable "jamfpro_auth_method" {
 variable "jamfpro_client_id" {
   description = "Jamf Pro Client ID for authentication."
   type        = string
-  default     = ""
 }
 
 variable "jamfpro_client_secret" {
   description = "Jamf Pro Client Secret for authentication."
   type        = string
   sensitive   = true
-  default     = ""
 }
 
 variable "jamfpro_username" {


### PR DESCRIPTION
# Change

Removed default "" from parent var file. Will show as required credentials in Hashicorp registry

## Type of Change

Please delete options that are not relevant.

- [x] Refactor (refactoring code, removing code, changing code structure)


## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] For module changes - I have included an example in the /examples directory and a README.md in the module root
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated spec.yaml as appropriate
- [ ] I have checked `Terraform Init` and `Terraform Fmt`
- [ ] I have ran `Terraform Apply` against any active module changes
