### PR TITLE
Removed Random Entropy Identifier from Onboarder 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,10 +21,22 @@ provider "jsc" {
   applicationsecret = var.jsc_applicationsecret
 }
 
+resource "random_string" "entropy" {
+  count  = var.random_string_boolean == true ? 1 : 0
+  length = 12
+  upper  = true
+  lower  = true
+}
+
+locals {
+  random_string = var.random_string.entropy.result
+}
+
 # Onboarder Modules
 module "onboarder-all" {
-  count  = var.include_onboarder_all == true ? 1 : 0
-  source = "./modules/onboarder-all"
+  count         = var.include_onboarder_all == true ? 1 : 0
+  source        = "./modules/onboarder-all"
+  random_string = local.random_string
   providers = {
     jamfpro.jpro = jamfpro.jpro
     jsc.jsc      = jsc.jsc
@@ -32,16 +44,18 @@ module "onboarder-all" {
 }
 
 module "onboarder-management-macOS" {
-  count  = var.include_onboarder_management_macOS == true ? 1 : 0
-  source = "./modules/onboarder-management-macOS"
+  count         = var.include_onboarder_management_macOS == true ? 1 : 0
+  source        = "./modules/onboarder-management-macOS"
+  random_string = local.random_string
   providers = {
     jamfpro.jpro = jamfpro.jpro
   }
 }
 
 module "onboarder-management-mobile" {
-  count  = var.include_onboarder_management_mobile == true ? 1 : 0
-  source = "./modules/onboarder-management-mobile"
+  count         = var.include_onboarder_management_mobile == true ? 1 : 0
+  source        = "./modules/onboarder-management-mobile"
+  random_string = local.random_string
   providers = {
     jamfpro.jpro = jamfpro.jpro
   }

--- a/main.tf
+++ b/main.tf
@@ -21,22 +21,24 @@ provider "jsc" {
   applicationsecret = var.jsc_applicationsecret
 }
 
-resource "random_string" "entropy" {
-  count  = var.random_string_boolean == true ? 1 : 0
-  length = 12
-  upper  = true
-  lower  = true
-}
+## Uncomment the lines below to add a random identifier to the end of each item created by these modules. This helps prevent run-ins with duplicate resources being created. 
+## These are commented out by default for use in Onboarder as a one time apply does not need identifiers.
+## ---------------------------------------------------------------
+# resource "random_integer" "entropy" {
+#   min = 10
+#   max = 999
+# }
 
-locals {
-  random_string = var.random_string.entropy.result
-}
+# locals {
+#   entropy_string = "[Run ID # ${random_integer.entropy.result}]"
+# }
+## ---------------------------------------------------------------
 
 # Onboarder Modules
 module "onboarder-all" {
-  count         = var.include_onboarder_all == true ? 1 : 0
-  source        = "./modules/onboarder-all"
-  random_string = local.random_string
+  count          = var.include_onboarder_all == true ? 1 : 0
+  source         = "./modules/onboarder-all"
+  entropy_string = var.entropy_string
   providers = {
     jamfpro.jpro = jamfpro.jpro
     jsc.jsc      = jsc.jsc
@@ -44,26 +46,27 @@ module "onboarder-all" {
 }
 
 module "onboarder-management-macOS" {
-  count         = var.include_onboarder_management_macOS == true ? 1 : 0
-  source        = "./modules/onboarder-management-macOS"
-  random_string = local.random_string
+  count          = var.include_onboarder_management_macOS == true ? 1 : 0
+  source         = "./modules/onboarder-management-macOS"
+  entropy_string = var.entropy_string
   providers = {
     jamfpro.jpro = jamfpro.jpro
   }
 }
 
 module "onboarder-management-mobile" {
-  count         = var.include_onboarder_management_mobile == true ? 1 : 0
-  source        = "./modules/onboarder-management-mobile"
-  random_string = local.random_string
+  count          = var.include_onboarder_management_mobile == true ? 1 : 0
+  source         = "./modules/onboarder-management-mobile"
+  entropy_string = var.entropy_string
   providers = {
     jamfpro.jpro = jamfpro.jpro
   }
 }
 
 module "onboarder-app-installers" {
-  count  = var.include_onboarder_app_installers == true ? 1 : 0
-  source = "./modules/onboarder-app-installers"
+  count          = var.include_onboarder_app_installers == true ? 1 : 0
+  source         = "./modules/onboarder-app-installers"
+  entropy_string = var.entropy_string
   providers = {
     jamfpro.jpro = jamfpro.jpro
   }
@@ -76,6 +79,7 @@ module "onboarder-app-installers" {
 module "configuration-jamf-pro-jamf-protect" {
   count                       = var.include_jamf_protect_trial_kickstart == true ? 1 : 0
   source                      = "./modules/configuration-jamf-pro-jamf-protect"
+  entropy_string              = var.entropy_string
   jamfpro_instance_url        = var.jamfpro_instance_url
   jamfpro_client_id           = var.jamfpro_client_id
   jamfpro_client_secret       = var.jamfpro_client_secret
@@ -90,6 +94,7 @@ module "configuration-jamf-pro-jamf-protect" {
 module "compliance-macOS-cis-level-1" {
   count                 = var.include_mac_cis_lvl1_benchmark == true ? 1 : 0
   source                = "./modules/compliance-macOS-cis-level-1"
+  entropy_string        = var.entropy_string
   jamfpro_instance_url  = var.jamfpro_instance_url
   jamfpro_client_id     = var.jamfpro_client_id
   jamfpro_client_secret = var.jamfpro_client_secret
@@ -101,6 +106,7 @@ module "compliance-macOS-cis-level-1" {
 module "compliance-iOS-cis-level-1" {
   count                 = var.include_mobile_cis_lvl1_benchmark == true ? 1 : 0
   source                = "./modules/compliance-iOS-cis-level-1"
+  entropy_string        = var.entropy_string
   jamfpro_instance_url  = var.jamfpro_instance_url
   jamfpro_client_id     = var.jamfpro_client_id
   jamfpro_client_secret = var.jamfpro_client_secret
@@ -112,6 +118,7 @@ module "compliance-iOS-cis-level-1" {
 module "compliance-macOS-disa-stig" {
   count                 = var.include_mac_stig_benchmark == true ? 1 : 0
   source                = "./modules/compliance-macOS-disa-stig"
+  entropy_string        = var.entropy_string
   jamfpro_instance_url  = var.jamfpro_instance_url
   jamfpro_client_id     = var.jamfpro_client_id
   jamfpro_client_secret = var.jamfpro_client_secret
@@ -123,6 +130,7 @@ module "compliance-macOS-disa-stig" {
 module "compliance-iOS-disa-stig" {
   count                 = var.include_mobile_stig_benchmark == true ? 1 : 0
   source                = "./modules/compliance-iOS-disa-stig"
+  entropy_string        = var.entropy_string
   jamfpro_instance_url  = var.jamfpro_instance_url
   jamfpro_client_id     = var.jamfpro_client_id
   jamfpro_client_secret = var.jamfpro_client_secret
@@ -134,6 +142,7 @@ module "compliance-iOS-disa-stig" {
 module "compliance-macOS-nist-800-171" {
   count                 = var.include_mac_800_171_benchmark == true ? 1 : 0
   source                = "./modules/compliance-macOS-nist-800-171"
+  entropy_string        = var.entropy_string
   jamfpro_instance_url  = var.jamfpro_instance_url
   jamfpro_client_id     = var.jamfpro_client_id
   jamfpro_client_secret = var.jamfpro_client_secret
@@ -145,6 +154,7 @@ module "compliance-macOS-nist-800-171" {
 module "compliance-macOS-cmmc-level-1" {
   count                 = var.include_mac_cmmc_lvl1_benchmark == true ? 1 : 0
   source                = "./modules/compliance-macOS-cmmc-level-1"
+  entropy_string        = var.entropy_string
   jamfpro_instance_url  = var.jamfpro_instance_url
   jamfpro_client_id     = var.jamfpro_client_id
   jamfpro_client_secret = var.jamfpro_client_secret
@@ -156,6 +166,7 @@ module "compliance-macOS-cmmc-level-1" {
 module "configuration-jamf-pro-admin-sso" {
   count                 = var.include_jamf_pro_admin_sso == true ? 1 : 0
   source                = "./modules/configuration-jamf-pro-admin-sso"
+  entropy_string        = var.entropy_string
   jamfpro_instance_url  = var.jamfpro_instance_url
   jamfpro_client_id     = var.jamfpro_client_id
   jamfpro_client_secret = var.jamfpro_client_secret
@@ -167,6 +178,7 @@ module "configuration-jamf-pro-admin-sso" {
 module "configuration-jamf-pro-smart-groups" {
   count                 = var.include_qol_smart_groups == true ? 1 : 0
   source                = "./modules/configuration-jamf-pro-smart-groups"
+  entropy_string        = var.entropy_string
   jamfpro_instance_url  = var.jamfpro_instance_url
   jamfpro_client_id     = var.jamfpro_client_id
   jamfpro_client_secret = var.jamfpro_client_secret
@@ -189,6 +201,7 @@ module "management-macOS-microsoft-365" {
 module "configuration-jamf-pro-categories" {
   count                 = var.include_categories == true ? 1 : 0
   source                = "./modules/configuration-jamf-pro-categories"
+  entropy_string        = var.entropy_string
   jamfpro_instance_url  = var.jamfpro_instance_url
   jamfpro_client_id     = var.jamfpro_client_id
   jamfpro_client_secret = var.jamfpro_client_secret
@@ -200,6 +213,7 @@ module "configuration-jamf-pro-categories" {
 module "management-iOS-configuration-profiles" {
   count                 = var.include_mobile_device_kickstart == true ? 1 : 0
   source                = "./modules/management-iOS-configuration-profiles"
+  entropy_string        = var.entropy_string
   jamfpro_instance_url  = var.jamfpro_instance_url
   jamfpro_client_id     = var.jamfpro_client_id
   jamfpro_client_secret = var.jamfpro_client_secret
@@ -211,6 +225,7 @@ module "management-iOS-configuration-profiles" {
 module "configuration-jamf-pro-computer-management-settings" {
   count                 = var.include_computer_management_settings == true ? 1 : 0
   source                = "./modules/configuration-jamf-pro-computer-management-settings"
+  entropy_string        = var.entropy_string
   jamfpro_instance_url  = var.jamfpro_instance_url
   jamfpro_client_id     = var.jamfpro_client_id
   jamfpro_client_secret = var.jamfpro_client_secret
@@ -222,6 +237,7 @@ module "configuration-jamf-pro-computer-management-settings" {
 module "endpoint-security-macOS-filevault" {
   count                 = var.include_filevault == true ? 1 : 0
   source                = "./modules/endpoint-security-macOS-filevault"
+  entropy_string        = var.entropy_string
   jamfpro_instance_url  = var.jamfpro_instance_url
   jamfpro_client_id     = var.jamfpro_client_id
   jamfpro_client_secret = var.jamfpro_client_secret
@@ -233,6 +249,7 @@ module "endpoint-security-macOS-filevault" {
 module "endpoint-security-macOS-microsoft-defender" {
   count                 = var.include_defender == true ? 1 : 0
   source                = "./modules/endpoint-security-macOS-microsoft-defender"
+  entropy_string        = var.entropy_string
   jamfpro_instance_url  = var.jamfpro_instance_url
   jamfpro_client_id     = var.jamfpro_client_id
   jamfpro_client_secret = var.jamfpro_client_secret
@@ -244,6 +261,7 @@ module "endpoint-security-macOS-microsoft-defender" {
 module "management-macOS-SSOe-Okta" {
   count                 = var.include_ssoe_okta == true ? 1 : 0
   source                = "./modules/management-macOS-SSOe-Okta"
+  entropy_string        = var.entropy_string
   jamfpro_instance_url  = var.jamfpro_instance_url
   jamfpro_client_id     = var.jamfpro_client_id
   jamfpro_client_secret = var.jamfpro_client_secret
@@ -255,6 +273,7 @@ module "management-macOS-SSOe-Okta" {
 module "endpoint-security-macOS-crowdstrike" {
   count                 = var.include_crowdstrike == true ? 1 : 0
   source                = "./modules/endpoint-security-macOS-crowdstrike"
+  entropy_string        = var.entropy_string
   jamfpro_instance_url  = var.jamfpro_instance_url
   jamfpro_client_id     = var.jamfpro_client_id
   jamfpro_client_secret = var.jamfpro_client_secret
@@ -269,6 +288,7 @@ module "endpoint-security-macOS-crowdstrike" {
 module "management-macOS-rosetta" {
   count                 = var.include_rosetta == true ? 1 : 0
   source                = "./modules/management-macOS-rosetta"
+  entropy_string        = var.entropy_string
   jamfpro_instance_url  = var.jamfpro_instance_url
   jamfpro_client_id     = var.jamfpro_client_id
   jamfpro_client_secret = var.jamfpro_client_secret
@@ -279,6 +299,7 @@ module "management-macOS-rosetta" {
 
 module "management-app-installers" {
   source                = "./modules/management-app-installers"
+  entropy_string        = var.entropy_string
   for_each              = toset(var.app_installers)
   app_installer_name    = each.value
   jamfpro_instance_url  = var.jamfpro_instance_url
@@ -295,6 +316,7 @@ module "management-app-installers" {
 module "configuration-jamf-security-cloud-jamf-pro" {
   count                 = var.include_jsc_uemc == true ? 1 : 0
   source                = "./modules/configuration-jamf-security-cloud-jamf-pro"
+  entropy_string        = var.entropy_string
   jamfpro_instance_url  = var.jamfpro_instance_url
   jamfpro_client_id     = var.jamfpro_client_id
   jamfpro_client_secret = var.jamfpro_client_secret
@@ -310,6 +332,7 @@ module "configuration-jamf-security-cloud-jamf-pro" {
 module "configuration-jamf-security-cloud-all-services" {
   count                 = var.include_jsc_all_services == true ? 1 : 0
   source                = "./modules/configuration-jamf-security-cloud-all-services"
+  entropy_string        = var.entropy_string
   tje_okta_clientid     = var.tje_okta_clientid
   tje_okta_orgdomain    = var.tje_okta_orgdomain
   jsc_username          = var.jsc_username
@@ -325,6 +348,7 @@ module "configuration-jamf-security-cloud-all-services" {
 
 module "network-security-access-policy" {
   source             = "./modules/network-security-access-policy"
+  entropy_string     = var.entropy_string
   for_each           = toset(var.access_policies)
   access_policy_name = each.value
   jsc_username       = var.jsc_username
@@ -337,6 +361,7 @@ module "network-security-access-policy" {
 module "configuration-jamf-security-cloud-block-pages" {
   count           = var.include_jsc_block_pages == true ? 1 : 0
   source          = "./modules/configuration-jamf-security-cloud-block-pages"
+  entropy_string  = var.entropy_string
   block_page_logo = var.block_page_logo
   jsc_username    = var.jsc_username
   jsc_password    = var.jsc_password
@@ -349,6 +374,7 @@ module "configuration-jamf-security-cloud-block-pages" {
 module "network-security-jamf-pro-content-filtering" {
   count                 = var.include_jsc_dp_only == true ? 1 : 0
   source                = "./modules/network-security-jamf-pro-content-filtering"
+  entropy_string        = var.entropy_string
   tje_okta_clientid     = var.tje_okta_clientid
   tje_okta_orgdomain    = var.tje_okta_orgdomain
   jsc_username          = var.jsc_username
@@ -366,6 +392,7 @@ module "network-security-jamf-pro-content-filtering" {
 module "network-security-jamf-pro-network-threat-defense" {
   count                 = var.include_jsc_mtd_only == true ? 1 : 0
   source                = "./modules/network-security-jamf-pro-network-threat-defense"
+  entropy_string        = var.entropy_string
   tje_okta_clientid     = var.tje_okta_clientid
   tje_okta_orgdomain    = var.tje_okta_orgdomain
   jsc_username          = var.jsc_username
@@ -383,6 +410,7 @@ module "network-security-jamf-pro-network-threat-defense" {
 module "network-security-jamf-pro-content-filtering-and-network-threat-defense" {
   count                 = var.include_jsc_mtd_dp_only == true ? 1 : 0
   source                = "./modules/network-security-jamf-pro-content-filtering-and-network-threat-defense"
+  entropy_string        = var.entropy_string
   tje_okta_clientid     = var.tje_okta_clientid
   tje_okta_orgdomain    = var.tje_okta_orgdomain
   jsc_username          = var.jsc_username
@@ -400,6 +428,7 @@ module "network-security-jamf-pro-content-filtering-and-network-threat-defense" 
 module "network-security-jamf-pro-zero-trust-network-access" {
   count                 = var.include_jsc_ztna == true ? 1 : 0
   source                = "./modules/network-security-jamf-pro-zero-trust-network-access"
+  entropy_string        = var.entropy_string
   tje_okta_clientid     = var.tje_okta_clientid
   tje_okta_orgdomain    = var.tje_okta_orgdomain
   jsc_username          = var.jsc_username
@@ -417,6 +446,7 @@ module "network-security-jamf-pro-zero-trust-network-access" {
 module "network-security-jamf-pro-zero-trust-network-access-and-content-filtering" {
   count                 = var.include_jsc_ztna_dp_only == true ? 1 : 0
   source                = "./modules/network-security-jamf-pro-zero-trust-network-access-and-content-filtering"
+  entropy_string        = var.entropy_string
   tje_okta_clientid     = var.tje_okta_clientid
   tje_okta_orgdomain    = var.tje_okta_orgdomain
   jsc_username          = var.jsc_username
@@ -434,6 +464,7 @@ module "network-security-jamf-pro-zero-trust-network-access-and-content-filterin
 module "network-security-jamf-pro-zero-trust-network-access-and-network-threat-prevention" {
   count                 = var.include_jsc_ztna_mtd_only == true ? 1 : 0
   source                = "./modules/network-security-jamf-pro-zero-trust-network-access-and-network-threat-prevention"
+  entropy_string        = var.entropy_string
   tje_okta_clientid     = var.tje_okta_clientid
   tje_okta_orgdomain    = var.tje_okta_orgdomain
   jsc_username          = var.jsc_username

--- a/modules/compliance-iOS-cis-level-1/main.tf
+++ b/modules/compliance-iOS-cis-level-1/main.tf
@@ -8,24 +8,19 @@ terraform {
   }
 }
 
-resource "random_integer" "entropy" {
-  min = 10
-  max = 999
-}
-
 ## Create categories
 resource "jamfpro_category" "category_ios17_cis_benchmarks" {
-  name     = "iOS 17 - CIS Level 1 Benchmarks [${random_integer.entropy.result}]"
+  name     = "iOS 17 - CIS Level 1 Benchmarks ${var.entropy_string}"
   priority = 9
 }
 
 resource "jamfpro_category" "category_ios18_cis_benchmarks" {
-  name     = "iOS 18 - CIS Level 1 Benchmarks [${random_integer.entropy.result}]"
+  name     = "iOS 18 - CIS Level 1 Benchmarks ${var.entropy_string}"
   priority = 9
 }
 
 resource "jamfpro_smart_mobile_device_group" "group_ios17" {
-  name = "iOS 17 - CIS Level 1 [${random_integer.entropy.result}]"
+  name = "iOS 17 - CIS Level 1 ${var.entropy_string}"
 
   criteria {
     name        = "OS Version"
@@ -43,7 +38,7 @@ resource "jamfpro_smart_mobile_device_group" "group_ios17" {
 }
 
 resource "jamfpro_smart_mobile_device_group" "group_ios18" {
-  name = "iOS 18 - CIS Level 1 [${random_integer.entropy.result}]"
+  name = "iOS 18 - CIS Level 1 ${var.entropy_string}"
 
   criteria {
     name        = "OS Version"
@@ -71,7 +66,7 @@ locals {
 
 resource "jamfpro_mobile_device_configuration_profile_plist" "config_ios17" {
   for_each           = local.ios17_cis_lvl1_dict
-  name               = "iOS 17 CIS Level 1 - ${each.key} [${random_integer.entropy.result}]"
+  name               = "iOS 17 CIS Level 1 - ${each.key} ${var.entropy_string}"
   description        = "To scope this configuration profile, navigate to Smart Device Groups, select the 'iOS 17 - CIS Level 1' Smart Group and remove the placeholder serial number criteria."
   deployment_method  = "Install Automatically"
   level              = "Device Level"
@@ -98,7 +93,7 @@ locals {
 
 resource "jamfpro_mobile_device_configuration_profile_plist" "config_ios18" {
   for_each           = local.ios18_cis_lvl1_dict
-  name               = "iOS 18 CIS Level 1 - ${each.key} [${random_integer.entropy.result}]"
+  name               = "iOS 18 CIS Level 1 - ${each.key} ${var.entropy_string}"
   description        = "To scope this configuration profile, navigate to Smart Device Groups, select the 'iOS 18 - CIS Level 1' Smart Group and remove the placeholder serial number criteria."
   deployment_method  = "Install Automatically"
   level              = "Device Level"

--- a/modules/compliance-iOS-cis-level-1/variables.tf
+++ b/modules/compliance-iOS-cis-level-1/variables.tf
@@ -24,3 +24,8 @@ variable "jamfpro_client_secret" {
   type        = string
   sensitive   = true
 }
+
+variable "random_string" {
+  type    = string
+  default = ""
+}

--- a/modules/compliance-iOS-cis-level-1/variables.tf
+++ b/modules/compliance-iOS-cis-level-1/variables.tf
@@ -29,3 +29,8 @@ variable "random_string" {
   type    = string
   default = ""
 }
+
+variable "entropy_string" {
+  type    = string
+  default = ""
+}

--- a/modules/compliance-iOS-disa-stig/main.tf
+++ b/modules/compliance-iOS-disa-stig/main.tf
@@ -10,24 +10,19 @@ terraform {
 
 ## DISA STIG is not available for iOS 18 yet. Relevant resources are commented out until we can add support.
 
-resource "random_integer" "entropy" {
-  min = 10
-  max = 999
-}
-
 ## Create categories
 resource "jamfpro_category" "category_ios17_stig_benchmarks" {
-  name     = "iOS 17 - DISA STIG Benchmarks [${random_integer.entropy.result}]"
+  name     = "iOS 17 - DISA STIG Benchmarks ${var.entropy_string}"
   priority = 9
 }
 
 # resource "jamfpro_category" "category_ios18_cis_benchmarks" {
-#   name     = "iOS 18 - DISA STIG Benchmarks [${random_integer.entropy.result}]"
+#   name     = "iOS 18 - DISA STIG Benchmarks ${var.entropy_string}"
 #   priority = 9
 # }
 
 resource "jamfpro_smart_mobile_device_group" "group_ios17" {
-  name = "iOS 17 - DISA STIG [${random_integer.entropy.result}]"
+  name = "iOS 17 - DISA STIG ${var.entropy_string}"
 
   criteria {
     name        = "OS Version"
@@ -45,7 +40,7 @@ resource "jamfpro_smart_mobile_device_group" "group_ios17" {
 }
 
 # resource "jamfpro_smart_mobile_device_group" "group_ios18" {
-#   name = "iOS 18 - DISA STIG [${random_integer.entropy.result}]"
+#   name = "iOS 18 - DISA STIG ${var.entropy_string}"
 
 #   criteria {
 #     name        = "OS Version"
@@ -74,7 +69,7 @@ locals {
 
 resource "jamfpro_mobile_device_configuration_profile_plist" "config_ios17" {
   for_each           = local.ios17_stig_dict
-  name               = "iOS 17 DISA STIG - ${each.key} [${random_integer.entropy.result}]"
+  name               = "iOS 17 DISA STIG - ${each.key} ${var.entropy_string}"
   description        = "To scope this configuration profile, navigate to Smart Device Groups, select the 'iOS 17 - DISA STIG' Smart Group and remove the placeholder serial number criteria."
   deployment_method  = "Install Automatically"
   level              = "Device Level"
@@ -102,7 +97,7 @@ resource "jamfpro_mobile_device_configuration_profile_plist" "config_ios17" {
 
 # resource "jamfpro_mobile_device_configuration_profile_plist" "config_ios18" {
 #   for_each           = local.ios18_stig_dict
-#   name               = "iOS 18 DISA STIG - ${each.key} [${random_integer.entropy.result}]"
+#   name               = "iOS 18 DISA STIG - ${each.key} ${var.entropy_string}"
 #   deployment_method  = "Install Automatically"
 #   level              = "Device Level"
 #   redeploy_on_update = "Newly Assigned"

--- a/modules/compliance-iOS-disa-stig/variables.tf
+++ b/modules/compliance-iOS-disa-stig/variables.tf
@@ -25,3 +25,8 @@ variable "jamfpro_client_secret" {
   type        = string
   sensitive   = true
 }
+
+variable "random_string" {
+  type    = string
+  default = ""
+}

--- a/modules/compliance-iOS-disa-stig/variables.tf
+++ b/modules/compliance-iOS-disa-stig/variables.tf
@@ -30,3 +30,8 @@ variable "random_string" {
   type    = string
   default = ""
 }
+
+variable "entropy_string" {
+  type    = string
+  default = ""
+}

--- a/modules/compliance-macOS-cis-level-1/main.tf
+++ b/modules/compliance-macOS-cis-level-1/main.tf
@@ -8,25 +8,20 @@ terraform {
   }
 }
 
-resource "random_integer" "entropy" {
-  min = 10
-  max = 999
-}
-
 ## Create categories
 resource "jamfpro_category" "category_sonoma_cis_lvl1_benchmarks" {
-  name     = "Sonoma - CIS Level 1 Benchmarks [${random_integer.entropy.result}]"
+  name     = "Sonoma - CIS Level 1 Benchmarks ${var.entropy_string}"
   priority = 9
 }
 
 resource "jamfpro_category" "category_sequoia_cis_lvl1_benchmarks" {
-  name     = "Sequoia - CIS Level 1 Benchmarks [${random_integer.entropy.result}]"
+  name     = "Sequoia - CIS Level 1 Benchmarks ${var.entropy_string}"
   priority = 9
 }
 
 ## Create scripts
 resource "jamfpro_script" "script_sonoma_cis_lvl1_compliance" {
-  name            = "Sonoma - CIS Level 1 Compliance [${random_integer.entropy.result}]"
+  name            = "Sonoma - CIS Level 1 Compliance ${var.entropy_string}"
   priority        = "AFTER"
   script_contents = file("${path.module}/support_files/computer_scripts/sonoma_cis_lvl1_compliance.sh")
   category_id     = jamfpro_category.category_sonoma_cis_lvl1_benchmarks.id
@@ -34,7 +29,7 @@ resource "jamfpro_script" "script_sonoma_cis_lvl1_compliance" {
 }
 
 resource "jamfpro_script" "script_sequoia_cis_lvl1_compliance" {
-  name            = "Sequoia - CIS Level 1 Compliance [${random_integer.entropy.result}]"
+  name            = "Sequoia - CIS Level 1 Compliance ${var.entropy_string}"
   priority        = "AFTER"
   script_contents = file("${path.module}/support_files/computer_scripts/sequoia_cis_lvl1_compliance.sh")
   category_id     = jamfpro_category.category_sequoia_cis_lvl1_benchmarks.id
@@ -43,7 +38,7 @@ resource "jamfpro_script" "script_sequoia_cis_lvl1_compliance" {
 
 ## Create computer extension attributes
 resource "jamfpro_computer_extension_attribute" "ea_cis_lvl1_failed_count" {
-  name                   = "CIS Level 1 - Failed Results Count [${random_integer.entropy.result}]"
+  name                   = "CIS Level 1 - Failed Results Count"
   input_type             = "SCRIPT"
   enabled                = true
   data_type              = "INTEGER"
@@ -52,7 +47,7 @@ resource "jamfpro_computer_extension_attribute" "ea_cis_lvl1_failed_count" {
 }
 
 resource "jamfpro_computer_extension_attribute" "ea_cis_lvl1_failed_list" {
-  name                   = "CIS Level 1 - Failed Results List [${random_integer.entropy.result}]"
+  name                   = "CIS Level 1 - Failed Results List"
   input_type             = "SCRIPT"
   enabled                = true
   data_type              = "STRING"
@@ -61,7 +56,7 @@ resource "jamfpro_computer_extension_attribute" "ea_cis_lvl1_failed_list" {
 }
 
 resource "jamfpro_computer_extension_attribute" "ea_cis_lvl1_version" {
-  name                   = "Compliance Version [${random_integer.entropy.result}]"
+  name                   = "CIS Level 1 - Compliance Version"
   input_type             = "SCRIPT"
   enabled                = true
   data_type              = "STRING"
@@ -71,7 +66,7 @@ resource "jamfpro_computer_extension_attribute" "ea_cis_lvl1_version" {
 
 ## Create Smart Computer Groups
 resource "jamfpro_smart_computer_group" "group_sonoma_computers" {
-  name = "CIS Level 1 - Sonoma Computers [${random_integer.entropy.result}]"
+  name = "CIS Level 1 - Sonoma Computers ${var.entropy_string}"
   criteria {
     name        = "Operating System Version"
     search_type = "like"
@@ -89,7 +84,7 @@ resource "jamfpro_smart_computer_group" "group_sonoma_computers" {
 }
 
 resource "jamfpro_smart_computer_group" "group_sonoma_cis_lvl1_non_compliant" {
-  name = "CIS Level 1 - Sonoma - Non Compliant Computers [${random_integer.entropy.result}]"
+  name = "CIS Level 1 - Sonoma - Non Compliant Computers ${var.entropy_string}"
   criteria {
     name        = "Operating System Version"
     search_type = "like"
@@ -107,7 +102,7 @@ resource "jamfpro_smart_computer_group" "group_sonoma_cis_lvl1_non_compliant" {
 }
 
 resource "jamfpro_smart_computer_group" "group_sequoia_computers" {
-  name = "CIS Level 1 - Sequoia Computers [${random_integer.entropy.result}]"
+  name = "CIS Level 1 - Sequoia Computers ${var.entropy_string}"
   criteria {
     name        = "Operating System Version"
     search_type = "like"
@@ -125,7 +120,7 @@ resource "jamfpro_smart_computer_group" "group_sequoia_computers" {
 }
 
 resource "jamfpro_smart_computer_group" "group_sequoia_cis_lvl1_non_compliant" {
-  name = "CIS Level 1 - Sequoia - Non Compliant Computers [${random_integer.entropy.result}]"
+  name = "CIS Level 1 - Sequoia - Non Compliant Computers ${var.entropy_string}"
   criteria {
     name        = "Operating System Version"
     search_type = "like"
@@ -144,7 +139,7 @@ resource "jamfpro_smart_computer_group" "group_sequoia_cis_lvl1_non_compliant" {
 
 ## Create policies
 resource "jamfpro_policy" "policy_sonoma_cis_lvl1_audit" {
-  name            = "CIS Level 1 - Audit (Sonoma) [${random_integer.entropy.result}]"
+  name            = "CIS Level 1 - Audit (Sonoma) ${var.entropy_string}"
   enabled         = true
   trigger_checkin = true
   frequency       = "Ongoing"
@@ -182,7 +177,7 @@ resource "jamfpro_policy" "policy_sonoma_cis_lvl1_audit" {
 }
 
 resource "jamfpro_policy" "policy_sonoma_cis_lvl1_remediation" {
-  name            = "CIS Level 1 - Remediation (Sonoma) [${random_integer.entropy.result}]"
+  name            = "CIS Level 1 - Remediation (Sonoma) ${var.entropy_string}"
   enabled         = true
   trigger_checkin = true
   frequency       = "Ongoing"
@@ -222,7 +217,7 @@ resource "jamfpro_policy" "policy_sonoma_cis_lvl1_remediation" {
 }
 
 resource "jamfpro_policy" "policy_sequoia_cis_lvl1_audit" {
-  name            = "CIS Level 1 - Audit (Sequoia) [${random_integer.entropy.result}]"
+  name            = "CIS Level 1 - Audit (Sequoia) ${var.entropy_string}"
   enabled         = true
   trigger_checkin = true
   frequency       = "Ongoing"
@@ -260,7 +255,7 @@ resource "jamfpro_policy" "policy_sequoia_cis_lvl1_audit" {
 }
 
 resource "jamfpro_policy" "policy_sequoia_cis_lvl1_remediation" {
-  name            = "CIS Level 1 - Remediation (Sequoia) [${random_integer.entropy.result}]"
+  name            = "CIS Level 1 - Remediation (Sequoia) ${var.entropy_string}"
   enabled         = true
   trigger_checkin = true
   frequency       = "Ongoing"
@@ -321,7 +316,7 @@ locals {
 ## Create configuration profiles for Sonoma
 resource "jamfpro_macos_configuration_profile_plist" "sonoma_cis_lvl1" {
   for_each            = local.sonoma_cis_lvl1_dict
-  name                = "Sonoma CIS Level 1 - ${each.key} [${random_integer.entropy.result}]"
+  name                = "Sonoma CIS Level 1 - ${each.key} ${var.entropy_string}"
   description         = "To scope this configuration profile, navigate to Smart Computer Groups, select the 'CIS Level 1 - Sonoma Computers' Smart Group and remove the placeholder serial number criteria."
   distribution_method = "Install Automatically"
   redeploy_on_update  = "Newly Assigned"
@@ -363,7 +358,7 @@ locals {
 ## Create configuration profiles for Sequoia part 1
 resource "jamfpro_macos_configuration_profile_plist" "sequoia_cis_lvl1" {
   for_each            = local.sequoia_cis_lvl1_dict
-  name                = "Sequoia CIS Level 1 - ${each.key} [${random_integer.entropy.result}]"
+  name                = "Sequoia CIS Level 1 - ${each.key} ${var.entropy_string}"
   description         = "To scope this configuration profile, navigate to Smart Computer Groups, select the 'CIS Level 1 - Sequoia Computers' Smart Group and remove the placeholder serial number criteria."
   distribution_method = "Install Automatically"
   redeploy_on_update  = "Newly Assigned"

--- a/modules/compliance-macOS-cis-level-1/variables.tf
+++ b/modules/compliance-macOS-cis-level-1/variables.tf
@@ -25,3 +25,8 @@ variable "jamfpro_client_secret" {
   type        = string
   sensitive   = true
 }
+
+variable "random_string" {
+  type    = string
+  default = ""
+}

--- a/modules/compliance-macOS-cis-level-1/variables.tf
+++ b/modules/compliance-macOS-cis-level-1/variables.tf
@@ -30,3 +30,8 @@ variable "random_string" {
   type    = string
   default = ""
 }
+
+variable "entropy_string" {
+  type    = string
+  default = ""
+}

--- a/modules/compliance-macOS-cmmc-level-1/main.tf
+++ b/modules/compliance-macOS-cmmc-level-1/main.tf
@@ -8,25 +8,20 @@ terraform {
   }
 }
 
-resource "random_integer" "entropy" {
-  min = 10
-  max = 999
-}
-
 ## Create categories
 resource "jamfpro_category" "category_sonoma_cmmc_lvl1_benchmarks" {
-  name     = "Sonoma - US CMMC 2.0 Level 1 Benchmarks [${random_integer.entropy.result}]"
+  name     = "Sonoma - US CMMC 2.0 Level 1 Benchmarks ${var.entropy_string}"
   priority = 9
 }
 
 resource "jamfpro_category" "category_sequoia_cmmc_lvl1_benchmarks" {
-  name     = "Sequoia - US CMMC 2.0 Level 1 Benchmarks [${random_integer.entropy.result}]"
+  name     = "Sequoia - US CMMC 2.0 Level 1 Benchmarks ${var.entropy_string}"
   priority = 9
 }
 
 ## Create scripts
 resource "jamfpro_script" "script_sonoma_cmmc_lvl1_compliance" {
-  name            = "Sonoma - US CMMC 2.0 Level 1 Compliance [${random_integer.entropy.result}]"
+  name            = "Sonoma - US CMMC 2.0 Level 1 Compliance ${var.entropy_string}"
   priority        = "AFTER"
   script_contents = file("${path.module}/support_files/computer_scripts/sonoma_cmmc_lvl1_compliance.sh")
   category_id     = jamfpro_category.category_sonoma_cmmc_lvl1_benchmarks.id
@@ -34,7 +29,7 @@ resource "jamfpro_script" "script_sonoma_cmmc_lvl1_compliance" {
 }
 
 resource "jamfpro_script" "script_sequoia_cmmc_lvl1_compliance" {
-  name            = "Sequoia - US CMMC 2.0 Level 1 Compliance [${random_integer.entropy.result}]"
+  name            = "Sequoia - US CMMC 2.0 Level 1 Compliance ${var.entropy_string}"
   priority        = "AFTER"
   script_contents = file("${path.module}/support_files/computer_scripts/sequoia_cmmc_lvl1_compliance.sh")
   category_id     = jamfpro_category.category_sequoia_cmmc_lvl1_benchmarks.id
@@ -43,7 +38,7 @@ resource "jamfpro_script" "script_sequoia_cmmc_lvl1_compliance" {
 
 ## Create computer extension attributes
 resource "jamfpro_computer_extension_attribute" "ea_cmmc_lvl1_failed_count" {
-  name                   = "US CMMC 2.0 Level 1 - Failed Results Count [${random_integer.entropy.result}]"
+  name                   = "US CMMC 2.0 Level 1 - Failed Results Count"
   input_type             = "SCRIPT"
   enabled                = true
   data_type              = "INTEGER"
@@ -52,7 +47,7 @@ resource "jamfpro_computer_extension_attribute" "ea_cmmc_lvl1_failed_count" {
 }
 
 resource "jamfpro_computer_extension_attribute" "ea_cmmc_lvl1_failed_list" {
-  name                   = "US CMMC 2.0 Level 1 - Failed Results List [${random_integer.entropy.result}]"
+  name                   = "US CMMC 2.0 Level 1 - Failed Results List"
   input_type             = "SCRIPT"
   enabled                = true
   data_type              = "STRING"
@@ -61,7 +56,7 @@ resource "jamfpro_computer_extension_attribute" "ea_cmmc_lvl1_failed_list" {
 }
 
 resource "jamfpro_computer_extension_attribute" "ea_cmmc_lvl1_version" {
-  name                   = "Compliance Version [${random_integer.entropy.result}]"
+  name                   = "US CMMC 2.0 Level 1 - Compliance Version"
   input_type             = "SCRIPT"
   enabled                = true
   data_type              = "STRING"
@@ -71,7 +66,7 @@ resource "jamfpro_computer_extension_attribute" "ea_cmmc_lvl1_version" {
 
 ## Create Smart Computer Groups
 resource "jamfpro_smart_computer_group" "group_sonoma_computers" {
-  name = "US CMMC 2.0 Level 1 - Sonoma Computers [${random_integer.entropy.result}]"
+  name = "US CMMC 2.0 Level 1 - Sonoma Computers ${var.entropy_string}"
   criteria {
     name        = "Operating System Version"
     search_type = "like"
@@ -89,7 +84,7 @@ resource "jamfpro_smart_computer_group" "group_sonoma_computers" {
 }
 
 resource "jamfpro_smart_computer_group" "group_sonoma_cmmc_lvl1_non_compliant" {
-  name = "US CMMC 2.0 Level 1 - Sonoma - Non Compliant Computers [${random_integer.entropy.result}]"
+  name = "US CMMC 2.0 Level 1 - Sonoma - Non Compliant Computers ${var.entropy_string}"
   criteria {
     name        = "Operating System Version"
     search_type = "like"
@@ -107,7 +102,7 @@ resource "jamfpro_smart_computer_group" "group_sonoma_cmmc_lvl1_non_compliant" {
 }
 
 resource "jamfpro_smart_computer_group" "group_sequoia_computers" {
-  name = "US CMMC 2.0 Level 1 - Sequoia Computers [${random_integer.entropy.result}]"
+  name = "US CMMC 2.0 Level 1 - Sequoia Computers ${var.entropy_string}"
   criteria {
     name        = "Operating System Version"
     search_type = "like"
@@ -125,7 +120,7 @@ resource "jamfpro_smart_computer_group" "group_sequoia_computers" {
 }
 
 resource "jamfpro_smart_computer_group" "group_sequoia_cmmc_lvl1_non_compliant" {
-  name = "US CMMC 2.0 Level 1 - Sequoia - Non Compliant Computers [${random_integer.entropy.result}]"
+  name = "US CMMC 2.0 Level 1 - Sequoia - Non Compliant Computers ${var.entropy_string}"
   criteria {
     name        = "Operating System Version"
     search_type = "like"
@@ -144,7 +139,7 @@ resource "jamfpro_smart_computer_group" "group_sequoia_cmmc_lvl1_non_compliant" 
 
 ## Create policies
 resource "jamfpro_policy" "policy_sonoma_cmmc_lvl1_audit" {
-  name            = "US CMMC 2.0 Level 1 - Audit (Sonoma) [${random_integer.entropy.result}]"
+  name            = "US CMMC 2.0 Level 1 - Audit (Sonoma) ${var.entropy_string}"
   enabled         = true
   trigger_checkin = true
   frequency       = "Ongoing"
@@ -182,7 +177,7 @@ resource "jamfpro_policy" "policy_sonoma_cmmc_lvl1_audit" {
 }
 
 resource "jamfpro_policy" "policy_sonoma_cmmc_lvl1_remediation" {
-  name            = "US CMMC 2.0 Level 1 - Remediation (Sonoma) [${random_integer.entropy.result}]"
+  name            = "US CMMC 2.0 Level 1 - Remediation (Sonoma) ${var.entropy_string}"
   enabled         = true
   trigger_checkin = true
   frequency       = "Ongoing"
@@ -222,7 +217,7 @@ resource "jamfpro_policy" "policy_sonoma_cmmc_lvl1_remediation" {
 }
 
 resource "jamfpro_policy" "policy_sequoia_cmmc_lvl1_audit" {
-  name            = "US CMMC 2.0 Level 1 - Audit (Sequoia) [${random_integer.entropy.result}]"
+  name            = "US CMMC 2.0 Level 1 - Audit (Sequoia) ${var.entropy_string}"
   enabled         = true
   trigger_checkin = true
   frequency       = "Ongoing"
@@ -260,7 +255,7 @@ resource "jamfpro_policy" "policy_sequoia_cmmc_lvl1_audit" {
 }
 
 resource "jamfpro_policy" "policy_sequoia_cmmc_lvl1_remediation" {
-  name            = "US CMMC 2.0 Level 1 - Remediation (Sequoia) [${random_integer.entropy.result}]"
+  name            = "US CMMC 2.0 Level 1 - Remediation (Sequoia) ${var.entropy_string}"
   enabled         = true
   trigger_checkin = true
   frequency       = "Ongoing"
@@ -321,7 +316,7 @@ locals {
 ## Create configuration profiles for Sonoma
 resource "jamfpro_macos_configuration_profile_plist" "sonoma_cmmc_lvl1" {
   for_each            = local.sonoma_cmmc_lvl1_dict
-  name                = "Sonoma US CMMC 2.0 Level 1 - ${each.key} [${random_integer.entropy.result}]"
+  name                = "Sonoma US CMMC 2.0 Level 1 - ${each.key} ${var.entropy_string}"
   description         = "To scope this configuration profile, navigate to Smart Computer Groups, select the 'US CMMC 2.0 Level 1 - Sonoma Computers' Smart Group and remove the placeholder serial number criteria."
   distribution_method = "Install Automatically"
   redeploy_on_update  = "Newly Assigned"
@@ -338,7 +333,7 @@ resource "jamfpro_macos_configuration_profile_plist" "sonoma_cmmc_lvl1" {
 }
 
 resource "jamfpro_macos_configuration_profile_plist" "sonoma_cmmc_lvl1_smart_card" {
-  name                = "Sonoma US CMMC 2.0 Level 1 - Smart Card [${random_integer.entropy.result}]"
+  name                = "Sonoma US CMMC 2.0 Level 1 - Smart Card ${var.entropy_string}"
   distribution_method = "Install Automatically"
   redeploy_on_update  = "Newly Assigned"
   category_id         = jamfpro_category.category_sonoma_cmmc_lvl1_benchmarks.id
@@ -375,7 +370,7 @@ locals {
 ## Create configuration profiles for Sequoia
 resource "jamfpro_macos_configuration_profile_plist" "sequoia_cmmc_lvl1" {
   for_each            = local.sequoia_cmmc_lvl1_dict
-  name                = "Sequoia US CMMC 2.0 Level 1 - ${each.key} [${random_integer.entropy.result}]"
+  name                = "Sequoia US CMMC 2.0 Level 1 - ${each.key} ${var.entropy_string}"
   description         = "To scope this configuration profile, navigate to Smart Computer Groups, select the 'US CMMC 2.0 Level 1 - Sequoia Computers' Smart Group and remove the placeholder serial number criteria."
   distribution_method = "Install Automatically"
   redeploy_on_update  = "Newly Assigned"
@@ -393,7 +388,7 @@ resource "jamfpro_macos_configuration_profile_plist" "sequoia_cmmc_lvl1" {
 }
 
 resource "jamfpro_macos_configuration_profile_plist" "sequoia_cmmc_lvl1_smart_card" {
-  name                = "Sequoia US CMMC 2.0 Level 1 - Smart Card [${random_integer.entropy.result}]"
+  name                = "Sequoia US CMMC 2.0 Level 1 - Smart Card ${var.entropy_string}"
   distribution_method = "Install Automatically"
   redeploy_on_update  = "Newly Assigned"
   category_id         = jamfpro_category.category_sequoia_cmmc_lvl1_benchmarks.id

--- a/modules/compliance-macOS-cmmc-level-1/variables.tf
+++ b/modules/compliance-macOS-cmmc-level-1/variables.tf
@@ -25,3 +25,8 @@ variable "jamfpro_client_secret" {
   type        = string
   sensitive   = true
 }
+
+variable "random_string" {
+  type    = string
+  default = ""
+}

--- a/modules/compliance-macOS-cmmc-level-1/variables.tf
+++ b/modules/compliance-macOS-cmmc-level-1/variables.tf
@@ -30,3 +30,8 @@ variable "random_string" {
   type    = string
   default = ""
 }
+
+variable "entropy_string" {
+  type    = string
+  default = ""
+}

--- a/modules/compliance-macOS-disa-stig/main.tf
+++ b/modules/compliance-macOS-disa-stig/main.tf
@@ -8,25 +8,20 @@ terraform {
   }
 }
 
-resource "random_integer" "entropy" {
-  min = 10
-  max = 999
-}
-
 ## Create categories
 resource "jamfpro_category" "category_sonoma_stig_benchmarks" {
-  name     = "Sonoma - DISA STIG Benchmarks [${random_integer.entropy.result}]"
+  name     = "Sonoma - DISA STIG Benchmarks ${var.entropy_string}"
   priority = 9
 }
 
 resource "jamfpro_category" "category_sequoia_stig_benchmarks" {
-  name     = "Sequoia - DISA STIG Benchmarks [${random_integer.entropy.result}]"
+  name     = "Sequoia - DISA STIG Benchmarks ${var.entropy_string}"
   priority = 9
 }
 
 ## Create scripts
 resource "jamfpro_script" "script_sonoma_stig_compliance" {
-  name            = "Sonoma - DISA STIG Compliance [${random_integer.entropy.result}]"
+  name            = "Sonoma - DISA STIG Compliance ${var.entropy_string}"
   priority        = "AFTER"
   script_contents = file("${path.module}/support_files/computer_scripts/sonoma_stig_compliance.sh")
   category_id     = jamfpro_category.category_sonoma_stig_benchmarks.id
@@ -34,7 +29,7 @@ resource "jamfpro_script" "script_sonoma_stig_compliance" {
 }
 
 resource "jamfpro_script" "script_sequoia_stig_compliance" {
-  name            = "Sequoia - DISA STIG Compliance [${random_integer.entropy.result}]"
+  name            = "Sequoia - DISA STIG Compliance ${var.entropy_string}"
   priority        = "AFTER"
   script_contents = file("${path.module}/support_files/computer_scripts/sequoia_stig_compliance.sh")
   category_id     = jamfpro_category.category_sequoia_stig_benchmarks.id
@@ -43,7 +38,7 @@ resource "jamfpro_script" "script_sequoia_stig_compliance" {
 
 ## Create computer extension attributes
 resource "jamfpro_computer_extension_attribute" "ea_stig_failed_count" {
-  name                   = "DISA STIG - Failed Results Count [${random_integer.entropy.result}]"
+  name                   = "DISA STIG - Failed Results Count"
   input_type             = "SCRIPT"
   enabled                = true
   data_type              = "INTEGER"
@@ -52,7 +47,7 @@ resource "jamfpro_computer_extension_attribute" "ea_stig_failed_count" {
 }
 
 resource "jamfpro_computer_extension_attribute" "ea_stig_failed_list" {
-  name                   = "DISA STIG - Failed Results List [${random_integer.entropy.result}]"
+  name                   = "DISA STIG - Failed Results List"
   input_type             = "SCRIPT"
   enabled                = true
   data_type              = "STRING"
@@ -61,7 +56,7 @@ resource "jamfpro_computer_extension_attribute" "ea_stig_failed_list" {
 }
 
 resource "jamfpro_computer_extension_attribute" "ea_stig_version" {
-  name                   = "Compliance Version [${random_integer.entropy.result}]"
+  name                   = "DISA STIG - Compliance Version"
   input_type             = "SCRIPT"
   enabled                = true
   data_type              = "STRING"
@@ -71,7 +66,7 @@ resource "jamfpro_computer_extension_attribute" "ea_stig_version" {
 
 ## Create Smart Computer Groups
 resource "jamfpro_smart_computer_group" "group_sonoma_computers" {
-  name = "DISA STIG - Sonoma Computers [${random_integer.entropy.result}]"
+  name = "DISA STIG - Sonoma Computers ${var.entropy_string}"
   criteria {
     name        = "Operating System Version"
     search_type = "like"
@@ -89,7 +84,7 @@ resource "jamfpro_smart_computer_group" "group_sonoma_computers" {
 }
 
 resource "jamfpro_smart_computer_group" "group_sonoma_stig_non_compliant" {
-  name = "DISA STIG - Sonoma - Non Compliant Computers [${random_integer.entropy.result}]"
+  name = "DISA STIG - Sonoma - Non Compliant Computers ${var.entropy_string}"
   criteria {
     name        = "Operating System Version"
     search_type = "like"
@@ -107,7 +102,7 @@ resource "jamfpro_smart_computer_group" "group_sonoma_stig_non_compliant" {
 }
 
 resource "jamfpro_smart_computer_group" "group_sequoia_computers" {
-  name = "DISA STIG - Sequoia Computers [${random_integer.entropy.result}]"
+  name = "DISA STIG - Sequoia Computers ${var.entropy_string}"
   criteria {
     name        = "Operating System Version"
     search_type = "like"
@@ -125,7 +120,7 @@ resource "jamfpro_smart_computer_group" "group_sequoia_computers" {
 }
 
 resource "jamfpro_smart_computer_group" "group_sequoia_stig_non_compliant" {
-  name = "DISA STIG - Sequoia - Non Compliant Computers [${random_integer.entropy.result}]"
+  name = "DISA STIG - Sequoia - Non Compliant Computers ${var.entropy_string}"
   criteria {
     name        = "Operating System Version"
     search_type = "like"
@@ -144,7 +139,7 @@ resource "jamfpro_smart_computer_group" "group_sequoia_stig_non_compliant" {
 
 ## Create policies
 resource "jamfpro_policy" "policy_sonoma_stig_audit" {
-  name            = "DISA STIG - Audit (Sonoma) [${random_integer.entropy.result}]"
+  name            = "DISA STIG - Audit (Sonoma) ${var.entropy_string}"
   enabled         = true
   trigger_checkin = true
   frequency       = "Ongoing"
@@ -182,7 +177,7 @@ resource "jamfpro_policy" "policy_sonoma_stig_audit" {
 }
 
 resource "jamfpro_policy" "policy_sonoma_stig_remediation" {
-  name            = "DISA STIG - Remediation (Sonoma) [${random_integer.entropy.result}]"
+  name            = "DISA STIG - Remediation (Sonoma) ${var.entropy_string}"
   enabled         = true
   trigger_checkin = true
   frequency       = "Ongoing"
@@ -222,7 +217,7 @@ resource "jamfpro_policy" "policy_sonoma_stig_remediation" {
 }
 
 resource "jamfpro_policy" "policy_sequoia_stig_audit" {
-  name            = "DISA STIG - Audit (Sequoia) [${random_integer.entropy.result}]"
+  name            = "DISA STIG - Audit (Sequoia) ${var.entropy_string}"
   enabled         = true
   trigger_checkin = true
   frequency       = "Ongoing"
@@ -260,7 +255,7 @@ resource "jamfpro_policy" "policy_sequoia_stig_audit" {
 }
 
 resource "jamfpro_policy" "policy_sequoia_stig_remediation" {
-  name            = "DISA STIG - Remediation (Sequoia) [${random_integer.entropy.result}]"
+  name            = "DISA STIG - Remediation (Sequoia) ${var.entropy_string}"
   enabled         = true
   trigger_checkin = true
   frequency       = "Ongoing"
@@ -328,7 +323,7 @@ locals {
 ## Create configuration profiles for Sonoma
 resource "jamfpro_macos_configuration_profile_plist" "sonoma_stig" {
   for_each            = local.sonoma_stig_dict
-  name                = "Sonoma DISA STIG - ${each.key} [${random_integer.entropy.result}]"
+  name                = "Sonoma DISA STIG - ${each.key} ${var.entropy_string}"
   description         = "To scope this configuration profile, navigate to Smart Computer Groups, select the 'DISA STIG - Sonoma Computers' Smart Group and remove the placeholder serial number criteria."
   distribution_method = "Install Automatically"
   redeploy_on_update  = "Newly Assigned"
@@ -345,7 +340,7 @@ resource "jamfpro_macos_configuration_profile_plist" "sonoma_stig" {
 }
 
 resource "jamfpro_macos_configuration_profile_plist" "sonoma_stig_smart_card" {
-  name                = "Sonoma DISA STIG - Smart Card [${random_integer.entropy.result}]"
+  name                = "Sonoma DISA STIG - Smart Card ${var.entropy_string}"
   description         = "To scope this configuration profile, navigate to the Scope tab above and add the 'DISA STIG - Sonoma Computers' smart group. Then, be sure to navigate to Smart Computer Groups, select that group and remove the placeholder serial number. This configuration profile is not scoped intentionally due to potential issues that Smart Cards may cause on an endpoint."
   distribution_method = "Install Automatically"
   redeploy_on_update  = "Newly Assigned"
@@ -390,7 +385,7 @@ locals {
 ## Create configuration profiles for Sequoia part 1
 resource "jamfpro_macos_configuration_profile_plist" "sequoia_stig" {
   for_each            = local.sequoia_stig_dict
-  name                = "Sequoia DISA STIG - ${each.key} [${random_integer.entropy.result}]"
+  name                = "Sequoia DISA STIG - ${each.key} ${var.entropy_string}"
   description         = "To scope this configuration profile, navigate to Smart Computer Groups, select the 'DISA STIG - Sequoia Computers' Smart Group and remove the placeholder serial number criteria."
   distribution_method = "Install Automatically"
   redeploy_on_update  = "Newly Assigned"
@@ -408,7 +403,7 @@ resource "jamfpro_macos_configuration_profile_plist" "sequoia_stig" {
 }
 
 resource "jamfpro_macos_configuration_profile_plist" "sequoia_stig_smart_card" {
-  name                = "Sequoia DISA STIG - Smart Card [${random_integer.entropy.result}]"
+  name                = "Sequoia DISA STIG - Smart Card ${var.entropy_string}"
   description         = "To scope this configuration profile, navigate to the Scope tab above and add the 'DISA STIG - Sequoia Computers' smart group. Then, be sure to navigate to Smart Computer Groups, select that group and remove the placeholder serial number. This configuration profile is not scoped intentionally due to potential issues that Smart Cards may cause on an endpoint."
   distribution_method = "Install Automatically"
   redeploy_on_update  = "Newly Assigned"

--- a/modules/compliance-macOS-disa-stig/variables.tf
+++ b/modules/compliance-macOS-disa-stig/variables.tf
@@ -25,3 +25,8 @@ variable "jamfpro_client_secret" {
   type        = string
   sensitive   = true
 }
+
+variable "random_string" {
+  type    = string
+  default = ""
+}

--- a/modules/compliance-macOS-disa-stig/variables.tf
+++ b/modules/compliance-macOS-disa-stig/variables.tf
@@ -30,3 +30,8 @@ variable "random_string" {
   type    = string
   default = ""
 }
+
+variable "entropy_string" {
+  type    = string
+  default = ""
+}

--- a/modules/compliance-macOS-nist-800-171/main.tf
+++ b/modules/compliance-macOS-nist-800-171/main.tf
@@ -8,25 +8,20 @@ terraform {
   }
 }
 
-resource "random_integer" "entropy" {
-  min = 10
-  max = 999
-}
-
 ## Create categories
 resource "jamfpro_category" "category_sonoma_800_171_benchmarks" {
-  name     = "Sonoma - NIST 800-171 Benchmarks [${random_integer.entropy.result}]"
+  name     = "Sonoma - NIST 800-171 Benchmarks ${var.entropy_string}"
   priority = 9
 }
 
 resource "jamfpro_category" "category_sequoia_800_171_benchmarks" {
-  name     = "Sequoia - NIST 800-171 Benchmarks [${random_integer.entropy.result}]"
+  name     = "Sequoia - NIST 800-171 Benchmarks ${var.entropy_string}"
   priority = 9
 }
 
 ## Create scripts
 resource "jamfpro_script" "script_sonoma_800_171_compliance" {
-  name            = "Sonoma - NIST 800-171 Compliance [${random_integer.entropy.result}]"
+  name            = "Sonoma - NIST 800-171 Compliance ${var.entropy_string}"
   priority        = "AFTER"
   script_contents = file("${path.module}/support_files/computer_scripts/sonoma_800-171_compliance.sh")
   category_id     = jamfpro_category.category_sonoma_800_171_benchmarks.id
@@ -34,7 +29,7 @@ resource "jamfpro_script" "script_sonoma_800_171_compliance" {
 }
 
 resource "jamfpro_script" "script_sequoia_800_171_compliance" {
-  name            = "Sequoia - NIST 800-171 Compliance [${random_integer.entropy.result}]"
+  name            = "Sequoia - NIST 800-171 Compliance ${var.entropy_string}"
   priority        = "AFTER"
   script_contents = file("${path.module}/support_files/computer_scripts/sequoia_800-171_compliance.sh")
   category_id     = jamfpro_category.category_sequoia_800_171_benchmarks.id
@@ -43,7 +38,7 @@ resource "jamfpro_script" "script_sequoia_800_171_compliance" {
 
 ## Create computer extension attributes
 resource "jamfpro_computer_extension_attribute" "ea_800_171_failed_count" {
-  name                   = "NIST 800-171 - Failed Results Count [${random_integer.entropy.result}]"
+  name                   = "NIST 800-171 - Failed Results Count"
   input_type             = "SCRIPT"
   enabled                = true
   data_type              = "INTEGER"
@@ -52,7 +47,7 @@ resource "jamfpro_computer_extension_attribute" "ea_800_171_failed_count" {
 }
 
 resource "jamfpro_computer_extension_attribute" "ea_800_171_failed_list" {
-  name                   = "NIST 800-171 - Failed Results List [${random_integer.entropy.result}]"
+  name                   = "NIST 800-171 - Failed Results List"
   input_type             = "SCRIPT"
   enabled                = true
   data_type              = "STRING"
@@ -61,7 +56,7 @@ resource "jamfpro_computer_extension_attribute" "ea_800_171_failed_list" {
 }
 
 resource "jamfpro_computer_extension_attribute" "ea_800_171_version" {
-  name                   = "Compliance Version [${random_integer.entropy.result}]"
+  name                   = "NIST 800-171 - Compliance Version"
   input_type             = "SCRIPT"
   enabled                = true
   data_type              = "STRING"
@@ -71,7 +66,7 @@ resource "jamfpro_computer_extension_attribute" "ea_800_171_version" {
 
 ## Create Smart Computer Groups
 resource "jamfpro_smart_computer_group" "group_sonoma_computers" {
-  name = "NIST 800-171 - Sonoma Computers [${random_integer.entropy.result}]"
+  name = "NIST 800-171 - Sonoma Computers ${var.entropy_string}"
   criteria {
     name        = "Operating System Version"
     search_type = "like"
@@ -89,7 +84,7 @@ resource "jamfpro_smart_computer_group" "group_sonoma_computers" {
 }
 
 resource "jamfpro_smart_computer_group" "group_sonoma_800_171_non_compliant" {
-  name = "NIST 800-171 - Sonoma - Non Compliant Computers [${random_integer.entropy.result}]"
+  name = "NIST 800-171 - Sonoma - Non Compliant Computers ${var.entropy_string}"
   criteria {
     name        = "Operating System Version"
     search_type = "like"
@@ -107,7 +102,7 @@ resource "jamfpro_smart_computer_group" "group_sonoma_800_171_non_compliant" {
 }
 
 resource "jamfpro_smart_computer_group" "group_sequoia_computers" {
-  name = "NIST 800-171 - Sequoia Computers [${random_integer.entropy.result}]"
+  name = "NIST 800-171 - Sequoia Computers ${var.entropy_string}"
   criteria {
     name        = "Operating System Version"
     search_type = "like"
@@ -125,7 +120,7 @@ resource "jamfpro_smart_computer_group" "group_sequoia_computers" {
 }
 
 resource "jamfpro_smart_computer_group" "group_sequoia_800_171_non_compliant" {
-  name = "NIST 800-171 - Sequoia - Non Compliant Computers [${random_integer.entropy.result}]"
+  name = "NIST 800-171 - Sequoia - Non Compliant Computers ${var.entropy_string}"
   criteria {
     name        = "Operating System Version"
     search_type = "like"
@@ -144,7 +139,7 @@ resource "jamfpro_smart_computer_group" "group_sequoia_800_171_non_compliant" {
 
 ## Create policies
 resource "jamfpro_policy" "policy_sonoma_800_171_audit" {
-  name            = "NIST 800-171 - Audit (Sonoma) [${random_integer.entropy.result}]"
+  name            = "NIST 800-171 - Audit (Sonoma) ${var.entropy_string}"
   enabled         = true
   trigger_checkin = true
   frequency       = "Ongoing"
@@ -182,7 +177,7 @@ resource "jamfpro_policy" "policy_sonoma_800_171_audit" {
 }
 
 resource "jamfpro_policy" "policy_sonoma_800_171_remediation" {
-  name            = "NIST 800-171 - Remediation (Sonoma) [${random_integer.entropy.result}]"
+  name            = "NIST 800-171 - Remediation (Sonoma) ${var.entropy_string}"
   enabled         = true
   trigger_checkin = true
   frequency       = "Ongoing"
@@ -222,7 +217,7 @@ resource "jamfpro_policy" "policy_sonoma_800_171_remediation" {
 }
 
 resource "jamfpro_policy" "policy_sequoia_800_171_audit" {
-  name            = "NIST 800-171 - Audit (Sequoia) [${random_integer.entropy.result}]"
+  name            = "NIST 800-171 - Audit (Sequoia) ${var.entropy_string}"
   enabled         = true
   trigger_checkin = true
   frequency       = "Ongoing"
@@ -260,7 +255,7 @@ resource "jamfpro_policy" "policy_sequoia_800_171_audit" {
 }
 
 resource "jamfpro_policy" "policy_sequoia_800_171_remediation" {
-  name            = "NIST 800-171 - Remediation (Sequoia) [${random_integer.entropy.result}]"
+  name            = "NIST 800-171 - Remediation (Sequoia) ${var.entropy_string}"
   enabled         = true
   trigger_checkin = true
   frequency       = "Ongoing"
@@ -331,7 +326,7 @@ locals {
 ## Create configuration profiles for Sonoma
 resource "jamfpro_macos_configuration_profile_plist" "sonoma_800_171" {
   for_each            = local.sonoma_800_171_dict
-  name                = "Sonoma NIST 800-171 - ${each.key} [${random_integer.entropy.result}]"
+  name                = "Sonoma NIST 800-171 - ${each.key} ${var.entropy_string}"
   description         = "To scope this configuration profile, navigate to Smart Computer Groups, select the 'NIST 800-171 - Sonoma Computers' Smart Group and remove the placeholder serial number criteria."
   distribution_method = "Install Automatically"
   redeploy_on_update  = "Newly Assigned"
@@ -348,7 +343,7 @@ resource "jamfpro_macos_configuration_profile_plist" "sonoma_800_171" {
 }
 
 resource "jamfpro_macos_configuration_profile_plist" "sonoma_800_171_smart_card" {
-  name                = "Sonoma NIST 800-171 - Smart Card [${random_integer.entropy.result}]"
+  name                = "Sonoma NIST 800-171 - Smart Card ${var.entropy_string}"
   description         = "To scope this configuration profile, navigate to the Scope tab above and add the 'NIST 800-171 - Sonoma Computers' smart group. Then, be sure to navigate to Smart Computer Groups, select that group and remove the placeholder serial number. This configuration profile is not scoped intentionally due to potential issues that Smart Cards may cause on an endpoint."
   distribution_method = "Install Automatically"
   redeploy_on_update  = "Newly Assigned"
@@ -396,7 +391,7 @@ locals {
 ## Create configuration profiles for Sequoia part 1
 resource "jamfpro_macos_configuration_profile_plist" "sequoia_800_171" {
   for_each            = local.sequoia_800_171_dict
-  name                = "Sequoia NIST 800-171 - ${each.key} [${random_integer.entropy.result}]"
+  name                = "Sequoia NIST 800-171 - ${each.key} ${var.entropy_string}"
   description         = "To scope this configuration profile, navigate to Smart Computer Groups, select the 'NIST 800-171 - Sequoia Computers' Smart Group and remove the placeholder serial number criteria."
   distribution_method = "Install Automatically"
   redeploy_on_update  = "Newly Assigned"
@@ -414,7 +409,7 @@ resource "jamfpro_macos_configuration_profile_plist" "sequoia_800_171" {
 }
 
 resource "jamfpro_macos_configuration_profile_plist" "sequoia_800_171_smart_card" {
-  name                = "Sequoia NIST 800-171 - Smart Card [${random_integer.entropy.result}]"
+  name                = "Sequoia NIST 800-171 - Smart Card ${var.entropy_string}"
   description         = "To scope this configuration profile, navigate to the Scope tab above and add the 'NIST 800-171 - Sequoia Computers' smart group. Then, be sure to navigate to Smart Computer Groups, select that group and remove the placeholder serial number. This configuration profile is not scoped intentionally due to potential issues that Smart Cards may cause on an endpoint."
   distribution_method = "Install Automatically"
   redeploy_on_update  = "Newly Assigned"

--- a/modules/compliance-macOS-nist-800-171/variables.tf
+++ b/modules/compliance-macOS-nist-800-171/variables.tf
@@ -25,3 +25,8 @@ variable "jamfpro_client_secret" {
   type        = string
   sensitive   = true
 }
+
+variable "random_string" {
+  type    = string
+  default = ""
+}

--- a/modules/compliance-macOS-nist-800-171/variables.tf
+++ b/modules/compliance-macOS-nist-800-171/variables.tf
@@ -30,3 +30,8 @@ variable "random_string" {
   type    = string
   default = ""
 }
+
+variable "entropy_string" {
+  type    = string
+  default = ""
+}

--- a/modules/configuration-jamf-pro-admin-sso/variables.tf
+++ b/modules/configuration-jamf-pro-admin-sso/variables.tf
@@ -46,3 +46,8 @@ variable "random_string" {
   type    = string
   default = ""
 }
+
+variable "entropy_string" {
+  type    = string
+  default = ""
+}

--- a/modules/configuration-jamf-pro-admin-sso/variables.tf
+++ b/modules/configuration-jamf-pro-admin-sso/variables.tf
@@ -41,3 +41,8 @@ variable "jamfpro_auth_method" {
   type        = string
   default     = "oauth2" #basic or oauth2
 }
+
+variable "random_string" {
+  type    = string
+  default = ""
+}

--- a/modules/configuration-jamf-pro-categories/main.tf
+++ b/modules/configuration-jamf-pro-categories/main.tf
@@ -8,47 +8,41 @@ terraform {
   }
 }
 
-
 ## Categories not specific to an "outcome". If relative to an outcome the category is created in the specific outcome module
-
-resource "random_integer" "entropy" {
-  min = 10
-  max = 999
-}
 
 ## Create Categories
 
 resource "jamfpro_category" "category_communication" {
-  name     = "Communication [${random_integer.entropy.result}]"
+  name     = "Communication ${var.entropy_string}"
   priority = 9
 }
 
 resource "jamfpro_category" "category_developer_tools" {
-  name     = "Developer Tools [${random_integer.entropy.result}]"
+  name     = "Developer Tools ${var.entropy_string}"
   priority = 9
 }
 
 resource "jamfpro_category" "category_network" {
-  name     = "Network Security [${random_integer.entropy.result}]"
+  name     = "Network Security ${var.entropy_string}"
   priority = 9
 }
 
 resource "jamfpro_category" "category_printers" {
-  name     = "Printers [${random_integer.entropy.result}]"
+  name     = "Printers ${var.entropy_string}"
   priority = 9
 }
 
 resource "jamfpro_category" "category_productivity" {
-  name     = "Productivity [${random_integer.entropy.result}]"
+  name     = "Productivity ${var.entropy_string}"
   priority = 9
 }
 
 resource "jamfpro_category" "category_security_compliance" {
-  name     = "Security and Compliance [${random_integer.entropy.result}]"
+  name     = "Security and Compliance ${var.entropy_string}"
   priority = 9
 }
 
 resource "jamfpro_category" "category_uninstallers" {
-  name     = "Uninstallers [${random_integer.entropy.result}]"
+  name     = "Uninstallers ${var.entropy_string}"
   priority = 9
 }

--- a/modules/configuration-jamf-pro-categories/variables.tf
+++ b/modules/configuration-jamf-pro-categories/variables.tf
@@ -26,3 +26,8 @@ variable "random_string" {
   type    = string
   default = ""
 }
+
+variable "entropy_string" {
+  type    = string
+  default = ""
+}

--- a/modules/configuration-jamf-pro-categories/variables.tf
+++ b/modules/configuration-jamf-pro-categories/variables.tf
@@ -21,3 +21,8 @@ variable "jamfpro_client_secret" {
   type        = string
   sensitive   = true
 }
+
+variable "random_string" {
+  type    = string
+  default = ""
+}

--- a/modules/configuration-jamf-pro-computer-management-settings/variables.tf
+++ b/modules/configuration-jamf-pro-computer-management-settings/variables.tf
@@ -26,3 +26,8 @@ variable "random_string" {
   type    = string
   default = ""
 }
+
+variable "entropy_string" {
+  type    = string
+  default = ""
+}

--- a/modules/configuration-jamf-pro-computer-management-settings/variables.tf
+++ b/modules/configuration-jamf-pro-computer-management-settings/variables.tf
@@ -21,3 +21,8 @@ variable "jamfpro_client_secret" {
   type        = string
   sensitive   = true
 }
+
+variable "random_string" {
+  type    = string
+  default = ""
+}

--- a/modules/configuration-jamf-pro-jamf-protect/main.tf
+++ b/modules/configuration-jamf-pro-jamf-protect/main.tf
@@ -8,11 +8,6 @@ terraform {
   }
 }
 
-resource "random_integer" "entropy" {
-  min = 10
-  max = 999
-}
-
 # Define a resource to use the local-exec provisioner
 resource "null_resource" "run_script" {
 
@@ -40,7 +35,7 @@ resource "jamfpro_category" "category_jamfprotect_security" {
 # Create Smart Group and Congfiguration Profile to identify Sequoia Macs and make Jamf Protect a non removable system extension
 
 resource "jamfpro_smart_computer_group" "group_sequoia_computers_jamf_protect" {
-  name = "Macs on MacOS Sequoia (Jamf Protect System Extension Enforcement) [${random_integer.entropy.result}]"
+  name = "Macs on MacOS Sequoia (Jamf Protect System Extension Enforcement) ${var.entropy_string}"
   criteria {
     name        = "Operating System Version"
     search_type = "like"
@@ -51,7 +46,7 @@ resource "jamfpro_smart_computer_group" "group_sequoia_computers_jamf_protect" {
 }
 
 resource "jamfpro_macos_configuration_profile_plist" "jamfpro_macos_configuration_profile_jamf_protect_system_extension" {
-  name                = "Jamf Protect System Extension Enforcement [${random_integer.entropy.result}]"
+  name                = "Jamf Protect System Extension Enforcement ${var.entropy_string}"
   description         = "This configuration profile prevents users from disabling the Jamf Protect System Extension"
   level               = "System"
   redeploy_on_update  = "Newly Assigned"

--- a/modules/configuration-jamf-pro-jamf-protect/variables.tf
+++ b/modules/configuration-jamf-pro-jamf-protect/variables.tf
@@ -35,3 +35,8 @@ variable "jamfpro_auth_method" {
   type        = string
   default     = "oauth2" #basic or oauth2
 }
+
+variable "random_string" {
+  type    = string
+  default = ""
+}

--- a/modules/configuration-jamf-pro-jamf-protect/variables.tf
+++ b/modules/configuration-jamf-pro-jamf-protect/variables.tf
@@ -40,3 +40,8 @@ variable "random_string" {
   type    = string
   default = ""
 }
+
+variable "entropy_string" {
+  type    = string
+  default = ""
+}

--- a/modules/configuration-jamf-pro-smart-groups/main.tf
+++ b/modules/configuration-jamf-pro-smart-groups/main.tf
@@ -8,14 +8,9 @@ terraform {
   }
 }
 
-resource "random_integer" "entropy" {
-  min = 10
-  max = 999
-}
-
 ## Create Smart Computer Groups - Quality Of Life
 resource "jamfpro_smart_computer_group" "group_sonoma_computers" {
-  name = "*Sonoma Macs [${random_integer.entropy.result}]"
+  name = "*Sonoma Macs ${var.entropy_string}"
   criteria {
     name        = "Operating System Version"
     search_type = "like"
@@ -26,7 +21,7 @@ resource "jamfpro_smart_computer_group" "group_sonoma_computers" {
 }
 
 resource "jamfpro_smart_computer_group" "group_sequoia_computers" {
-  name = "*Sequoia Macs [${random_integer.entropy.result}]"
+  name = "*Sequoia Macs ${var.entropy_string}"
   criteria {
     name        = "Operating System Version"
     search_type = "like"
@@ -37,7 +32,7 @@ resource "jamfpro_smart_computer_group" "group_sequoia_computers" {
 }
 
 resource "jamfpro_smart_computer_group" "group_last_checkin" {
-  name = "*7 Days Since Last Check-In [${random_integer.entropy.result}]"
+  name = "*7 Days Since Last Check-In ${var.entropy_string}"
   criteria {
     name        = "Last Check-in"
     search_type = "more than x days ago"
@@ -48,7 +43,7 @@ resource "jamfpro_smart_computer_group" "group_last_checkin" {
 }
 
 resource "jamfpro_smart_computer_group" "group_available_swu" {
-  name = "*Available Software Updates [${random_integer.entropy.result}]"
+  name = "*Available Software Updates ${var.entropy_string}"
   criteria {
     name        = "Number of Available Updates"
     search_type = "more than"
@@ -61,7 +56,7 @@ resource "jamfpro_smart_computer_group" "group_available_swu" {
 ## Create Smart Mobile Device Groups - Quality Of Life
 
 resource "jamfpro_smart_mobile_device_group" "supervised_ios" {
-  name = "*Supervised Devices [${random_integer.entropy.result}]"
+  name = "*Supervised Devices ${var.entropy_string}"
 
   criteria {
     name        = "Supervised"
@@ -72,7 +67,7 @@ resource "jamfpro_smart_mobile_device_group" "supervised_ios" {
 }
 
 resource "jamfpro_smart_mobile_device_group" "unsupervised_ios" {
-  name = "*Un-Supervised Devices [${random_integer.entropy.result}]"
+  name = "*Un-Supervised Devices ${var.entropy_string}"
 
   criteria {
     name        = "Supervised"
@@ -83,7 +78,7 @@ resource "jamfpro_smart_mobile_device_group" "unsupervised_ios" {
 }
 
 resource "jamfpro_smart_mobile_device_group" "byod_ios" {
-  name = "*BYOD Devices [${random_integer.entropy.result}]"
+  name = "*BYOD Devices ${var.entropy_string}"
 
   criteria {
     name        = "Serial Number"
@@ -94,7 +89,7 @@ resource "jamfpro_smart_mobile_device_group" "byod_ios" {
 }
 
 resource "jamfpro_smart_mobile_device_group" "ios_17" {
-  name = "*Devices Running iOS 17 [${random_integer.entropy.result}]"
+  name = "*Devices Running iOS 17 ${var.entropy_string}"
 
   criteria {
     name        = "OS Version"
@@ -105,7 +100,7 @@ resource "jamfpro_smart_mobile_device_group" "ios_17" {
 }
 
 resource "jamfpro_smart_mobile_device_group" "ios_18" {
-  name = "*Devices Running iOS 18 [${random_integer.entropy.result}]"
+  name = "*Devices Running iOS 18 ${var.entropy_string}"
 
   criteria {
     name        = "OS Version"
@@ -116,7 +111,7 @@ resource "jamfpro_smart_mobile_device_group" "ios_18" {
 }
 
 resource "jamfpro_smart_mobile_device_group" "group_last_checkin" {
-  name = "*Last Check-In More Than a Week Ago [${random_integer.entropy.result}]"
+  name = "*Last Check-In More Than a Week Ago ${var.entropy_string}"
 
   criteria {
     name        = "Last Inventory Update"
@@ -127,7 +122,7 @@ resource "jamfpro_smart_mobile_device_group" "group_last_checkin" {
 }
 
 resource "jamfpro_smart_mobile_device_group" "group_used_space_above_75" {
-  name = "*Used Storage above 75 percent [${random_integer.entropy.result}]"
+  name = "*Used Storage above 75 percent ${var.entropy_string}"
 
   criteria {
     name        = "Used Space Percentage"
@@ -138,7 +133,7 @@ resource "jamfpro_smart_mobile_device_group" "group_used_space_above_75" {
 }
 
 resource "jamfpro_smart_mobile_device_group" "group_passcode_not_present" {
-  name = "*Passcode Not Present [${random_integer.entropy.result}]"
+  name = "*Passcode Not Present ${var.entropy_string}"
 
   criteria {
     name        = "Passcode Status"

--- a/modules/configuration-jamf-pro-smart-groups/variables.tf
+++ b/modules/configuration-jamf-pro-smart-groups/variables.tf
@@ -26,3 +26,8 @@ variable "random_string" {
   type    = string
   default = ""
 }
+
+variable "entropy_string" {
+  type    = string
+  default = ""
+}

--- a/modules/configuration-jamf-pro-smart-groups/variables.tf
+++ b/modules/configuration-jamf-pro-smart-groups/variables.tf
@@ -21,3 +21,8 @@ variable "jamfpro_client_secret" {
   type        = string
   sensitive   = true
 }
+
+variable "random_string" {
+  type    = string
+  default = ""
+}

--- a/modules/configuration-jamf-security-cloud-all-services/main.tf
+++ b/modules/configuration-jamf-security-cloud-all-services/main.tf
@@ -12,11 +12,6 @@ terraform {
   }
 }
 
-resource "random_integer" "entropy" {
-  min = 10
-  max = 999
-}
-
 resource "jsc_oktaidp" "okta_idp_base" {
   clientid  = var.tje_okta_clientid
   name      = "Okta IDP Integration"
@@ -24,7 +19,7 @@ resource "jsc_oktaidp" "okta_idp_base" {
 }
 
 resource "jsc_ap" "all_services" {
-  name             = "Jamf Connect ZTNA and Protect [${random_integer.entropy.result}]"
+  name             = "Jamf Connect ZTNA and Protect ${var.entropy_string}"
   idptype          = "OKTA"
   oktaconnectionid = jsc_oktaidp.okta_idp_base.id
   privateaccess    = true
@@ -33,12 +28,12 @@ resource "jsc_ap" "all_services" {
 }
 
 resource "jamfpro_category" "jsc_all_services_profiles" {
-  name     = "Jamf Security Cloud - Activation Profiles [${random_integer.entropy.result}]"
+  name     = "Jamf Security Cloud - Activation Profiles ${var.entropy_string}"
   priority = 9
 }
 
 resource "jamfpro_smart_computer_group" "all_macs" {
-  name = "All Computers [${random_integer.entropy.result}]"
+  name = "All Computers ${var.entropy_string}"
 
   criteria {
     name        = "Computer Group"
@@ -55,7 +50,7 @@ resource "jamfpro_smart_computer_group" "all_macs" {
 }
 
 resource "jamfpro_macos_configuration_profile_plist" "all_services_macos" {
-  name                = "Jamf Connect ZTNA + Jamf Protect Threat and Content Control - macOS (Supervised) [${random_integer.entropy.result}]"
+  name                = "Jamf Connect ZTNA + Jamf Protect Threat and Content Control - macOS (Supervised) ${var.entropy_string}"
   description         = "This configuration profile contains all the pieces you'll need to deploy and enforce ZTNA, Network Security, and Content Control. We have also created a Smart Group called 'All Computers' and scoped this configuration profile to it. To finalize scoping and get this onto devices, navigate to Smart Computer Groups, click on the 'All Computers' group and remove the serial number criteria with the 111222333444555 serial number."
   distribution_method = "Install Automatically"
   redeploy_on_update  = "Newly Assigned"
@@ -72,7 +67,7 @@ resource "jamfpro_macos_configuration_profile_plist" "all_services_macos" {
 }
 
 resource "jamfpro_smart_mobile_device_group" "supervised_devices" {
-  name = "Supervised Mobile Devices [${random_integer.entropy.result}]"
+  name = "Supervised Mobile Devices ${var.entropy_string}"
 
   criteria {
     name        = "Supervised"
@@ -89,7 +84,7 @@ resource "jamfpro_smart_mobile_device_group" "supervised_devices" {
 }
 
 resource "jamfpro_smart_mobile_device_group" "unsupervised_devices" {
-  name = "Unsupervised Mobile Devices [${random_integer.entropy.result}]"
+  name = "Unsupervised Mobile Devices ${var.entropy_string}"
 
   criteria {
     name        = "Supervised"
@@ -106,7 +101,7 @@ resource "jamfpro_smart_mobile_device_group" "unsupervised_devices" {
 }
 
 resource "jamfpro_smart_mobile_device_group" "byod" {
-  name = "BYOD Mobile Devices [${random_integer.entropy.result}]"
+  name = "BYOD Mobile Devices ${var.entropy_string}"
 
   criteria {
     name        = "Serial Number"
@@ -123,7 +118,7 @@ resource "jamfpro_smart_mobile_device_group" "byod" {
 }
 
 resource "jamfpro_mobile_device_configuration_profile_plist" "all_services_mobile_supervised" {
-  name               = "Jamf Connect ZTNA + Jamf Protect Threat and Content Control - Mobile (Supervised) [${random_integer.entropy.result}]"
+  name               = "Jamf Connect ZTNA + Jamf Protect Threat and Content Control - Mobile (Supervised) ${var.entropy_string}"
   description        = "This configuration profile contains all the pieces you'll need to deploy and enforce ZTNA, Network Security, and Content Control. We have also created a Smart Group called 'Supervised Mobile Devices' and scoped this configuration profile to it. To finalize scoping and get this onto devices, navigate to Smart Computer Groups, click on the 'Supervised Mobile Devices' group and remove the serial number criteria with the 111222333444555 serial number."
   deployment_method  = "Install Automatically"
   level              = "Device Level"
@@ -141,7 +136,7 @@ resource "jamfpro_mobile_device_configuration_profile_plist" "all_services_mobil
 }
 
 resource "jamfpro_mobile_device_configuration_profile_plist" "all_services_mobile_unsupervised" {
-  name               = "Jamf Connect ZTNA + Jamf Protect Threat and Content Control - Mobile (Unsupervised) [${random_integer.entropy.result}]"
+  name               = "Jamf Connect ZTNA + Jamf Protect Threat and Content Control - Mobile (Unsupervised) ${var.entropy_string}"
   description        = "This configuration profile contains all the pieces you'll need to deploy and enforce ZTNA, Network Security, and Content Control. We have also created a Smart Group called 'Unsupervised Mobile Devices' and scoped this configuration profile to it. To finalize scoping and get this onto devices, navigate to Smart Computer Groups, click on the 'Unsupervised Mobile Devices' group and remove the serial number criteria with the 111222333444555 serial number."
   deployment_method  = "Install Automatically"
   level              = "Device Level"
@@ -159,7 +154,7 @@ resource "jamfpro_mobile_device_configuration_profile_plist" "all_services_mobil
 }
 
 resource "jamfpro_mobile_device_configuration_profile_plist" "all_services_mobile_byod" {
-  name               = "Jamf Connect ZTNA + Jamf Protect Threat and Content Control - Mobile (BYOD) [${random_integer.entropy.result}]"
+  name               = "Jamf Connect ZTNA + Jamf Protect Threat and Content Control - Mobile (BYOD) ${var.entropy_string}"
   description        = "This configuration profile contains all the pieces you'll need to deploy and enforce ZTNA, Network Security, and Content Control. We have also created a Smart Group called 'BYOD Mobile Devices' and scoped this configuration profile to it. To finalize scoping and get this onto devices, navigate to Smart Computer Groups, click on the 'BYOD Mobile Devices' group and remove the serial number criteria with the 111222333444555 serial number."
   deployment_method  = "Install Automatically"
   level              = "Device Level"

--- a/modules/configuration-jamf-security-cloud-all-services/variables.tf
+++ b/modules/configuration-jamf-security-cloud-all-services/variables.tf
@@ -88,3 +88,8 @@ variable "supervisedplist_output" {
   type    = string
   default = ""
 }
+
+variable "random_string" {
+  type    = string
+  default = ""
+}

--- a/modules/configuration-jamf-security-cloud-all-services/variables.tf
+++ b/modules/configuration-jamf-security-cloud-all-services/variables.tf
@@ -93,3 +93,8 @@ variable "random_string" {
   type    = string
   default = ""
 }
+
+variable "entropy_string" {
+  type    = string
+  default = ""
+}

--- a/modules/configuration-jamf-security-cloud-block-pages/variables.tf
+++ b/modules/configuration-jamf-security-cloud-block-pages/variables.tf
@@ -15,3 +15,8 @@ variable "jsc_password" {
   sensitive = true
   default   = ""
 }
+
+variable "random_string" {
+  type    = string
+  default = ""
+}

--- a/modules/configuration-jamf-security-cloud-block-pages/variables.tf
+++ b/modules/configuration-jamf-security-cloud-block-pages/variables.tf
@@ -20,3 +20,8 @@ variable "random_string" {
   type    = string
   default = ""
 }
+
+variable "entropy_string" {
+  type    = string
+  default = ""
+}

--- a/modules/configuration-jamf-security-cloud-jamf-pro/variables.tf
+++ b/modules/configuration-jamf-security-cloud-jamf-pro/variables.tf
@@ -39,3 +39,8 @@ variable "random_string" {
   type    = string
   default = ""
 }
+
+variable "entropy_string" {
+  type    = string
+  default = ""
+}

--- a/modules/configuration-jamf-security-cloud-jamf-pro/variables.tf
+++ b/modules/configuration-jamf-security-cloud-jamf-pro/variables.tf
@@ -34,3 +34,8 @@ variable "jamfpro_client_secret" {
   sensitive   = true
   default     = ""
 }
+
+variable "random_string" {
+  type    = string
+  default = ""
+}

--- a/modules/endpoint-security-macOS-crowdstrike/variables.tf
+++ b/modules/endpoint-security-macOS-crowdstrike/variables.tf
@@ -36,3 +36,8 @@ variable "falcon_customer_id" {
   description = "Falcon Customer ID"
   type        = string
 }
+
+variable "random_string" {
+  type    = string
+  default = ""
+}

--- a/modules/endpoint-security-macOS-crowdstrike/variables.tf
+++ b/modules/endpoint-security-macOS-crowdstrike/variables.tf
@@ -41,3 +41,8 @@ variable "random_string" {
   type    = string
   default = ""
 }
+
+variable "entropy_string" {
+  type    = string
+  default = ""
+}

--- a/modules/endpoint-security-macOS-filevault/main.tf
+++ b/modules/endpoint-security-macOS-filevault/main.tf
@@ -8,20 +8,15 @@ terraform {
   }
 }
 
-resource "random_integer" "entropy" {
-  min = 10
-  max = 999
-}
-
 ## Create Categories
 resource "jamfpro_category" "category_disk_encrpytion" {
-  name     = "Disk Encryption [${random_integer.entropy.result}]"
+  name     = "Disk Encryption ${var.entropy_string}"
   priority = 9
 }
 
 ## Create scripts
 resource "jamfpro_script" "script_reissuekey" {
-  name            = "Reissue FileVault 2 Key [${random_integer.entropy.result}]"
+  name            = "Reissue FileVault 2 Key ${var.entropy_string}"
   priority        = "AFTER"
   script_contents = file("${path.module}/support_files/reissuekey.sh")
   category_id     = jamfpro_category.category_disk_encrpytion.id
@@ -30,7 +25,7 @@ resource "jamfpro_script" "script_reissuekey" {
 
 ## Create Smart Computer Groups - Scoping
 resource "jamfpro_smart_computer_group" "group_invalid_recovery_key" {
-  name = "Invalid FileVault 2 Recovery Key [${random_integer.entropy.result}]"
+  name = "Invalid FileVault 2 Recovery Key ${var.entropy_string}"
   criteria {
     name        = "FileVault 2 Partition Encryption State"
     search_type = "is"
@@ -48,7 +43,7 @@ resource "jamfpro_smart_computer_group" "group_invalid_recovery_key" {
 }
 
 resource "jamfpro_smart_computer_group" "group_disk_encrypted" {
-  name = "* FileVault 2 Enabled [${random_integer.entropy.result}]"
+  name = "* FileVault 2 Enabled ${var.entropy_string}"
   criteria {
     name        = "FileVault 2 Partition Encryption State"
     search_type = "is"
@@ -60,7 +55,7 @@ resource "jamfpro_smart_computer_group" "group_disk_encrypted" {
 
 ## Create policies
 resource "jamfpro_policy" "policy_reissue_recovery_key" {
-  name          = "Reissue FileVault 2 Recovery Key [${random_integer.entropy.result}]"
+  name          = "Reissue FileVault 2 Recovery Key ${var.entropy_string}"
   enabled       = true
   trigger_other = ""
   frequency     = "Ongoing"
@@ -106,7 +101,7 @@ resource "jamfpro_policy" "policy_reissue_recovery_key" {
 }
 
 resource "jamfpro_macos_configuration_profile_plist" "jamfpro_macos_configuration_profile_enablefv" {
-  name                = "Enable FileVault 2 [${random_integer.entropy.result}]"
+  name                = "Enable FileVault 2 ${var.entropy_string}"
   description         = "This configuration profile enforces FileVault 2 encryption. Prompts at next login"
   level               = "System"
   category_id         = jamfpro_category.category_disk_encrpytion.id

--- a/modules/endpoint-security-macOS-filevault/variables.tf
+++ b/modules/endpoint-security-macOS-filevault/variables.tf
@@ -20,3 +20,8 @@ variable "jamfpro_client_secret" {
   type        = string
   sensitive   = true
 }
+
+variable "random_string" {
+  type    = string
+  default = ""
+}

--- a/modules/endpoint-security-macOS-filevault/variables.tf
+++ b/modules/endpoint-security-macOS-filevault/variables.tf
@@ -25,3 +25,8 @@ variable "random_string" {
   type    = string
   default = ""
 }
+
+variable "entropy_string" {
+  type    = string
+  default = ""
+}

--- a/modules/endpoint-security-macOS-microsoft-defender/main.tf
+++ b/modules/endpoint-security-macOS-microsoft-defender/main.tf
@@ -13,7 +13,6 @@ data "http" "defender_combined" {
   url = "https://raw.githubusercontent.com/microsoft/mdatp-xplat/refs/heads/master/macos/mobileconfig/combined/mdatp.mobileconfig"
 }
 
-
 ## Create Categories
 resource "jamfpro_category" "category_defender" {
   name     = "MS Windows Defender"

--- a/modules/endpoint-security-macOS-microsoft-defender/variables.tf
+++ b/modules/endpoint-security-macOS-microsoft-defender/variables.tf
@@ -28,3 +28,8 @@ variable "random_string" {
   type    = string
   default = ""
 }
+
+variable "entropy_string" {
+  type    = string
+  default = ""
+}

--- a/modules/endpoint-security-macOS-microsoft-defender/variables.tf
+++ b/modules/endpoint-security-macOS-microsoft-defender/variables.tf
@@ -23,3 +23,8 @@ variable "jamfpro_client_secret" {
   sensitive   = true
   default     = ""
 }
+
+variable "random_string" {
+  type    = string
+  default = ""
+}

--- a/modules/management-app-installers/variables.tf
+++ b/modules/management-app-installers/variables.tf
@@ -153,3 +153,8 @@ variable "self_service_description" {
   type        = string
   default     = "This is an app provided from your Self Service Provider."
 }
+
+variable "random_string" {
+  type    = string
+  default = ""
+}

--- a/modules/management-app-installers/variables.tf
+++ b/modules/management-app-installers/variables.tf
@@ -158,3 +158,8 @@ variable "random_string" {
   type    = string
   default = ""
 }
+
+variable "entropy_string" {
+  type    = string
+  default = ""
+}

--- a/modules/management-iOS-configuration-profiles/main.tf
+++ b/modules/management-iOS-configuration-profiles/main.tf
@@ -18,25 +18,20 @@ terraform {
   }
 }
 
-resource "random_integer" "entropy" {
-  min = 10
-  max = 999
-}
-
 ## Create Categories
 resource "jamfpro_category" "category_restrictions" {
-  name     = "Restrictions [${random_integer.entropy.result}]"
+  name     = "Restrictions ${var.entropy_string}"
   priority = 9
 }
 
 resource "jamfpro_category" "category_demo" {
-  name     = "Demo [${random_integer.entropy.result}]"
+  name     = "Demo ${var.entropy_string}"
   priority = 9
 }
 
 
 resource "jamfpro_mobile_device_configuration_profile_plist" "mobile_device_configuration_profile_restrict_apple_id_changes" {
-  name               = "Restrict Apple Account Changes [${random_integer.entropy.result}]"
+  name               = "Restrict Apple Account Changes ${var.entropy_string}"
   description        = "This restricts the ability to modify account settings for Apple ID"
   deployment_method  = "Install Automatically"
   level              = "Device Level"
@@ -50,7 +45,7 @@ resource "jamfpro_mobile_device_configuration_profile_plist" "mobile_device_conf
 }
 
 resource "jamfpro_mobile_device_configuration_profile_plist" "mobile_device_configuration_profile_restrict_airdrop" {
-  name               = "Restrict AirDrop [${random_integer.entropy.result}]"
+  name               = "Restrict AirDrop ${var.entropy_string}"
   description        = "This restricts the ability to use AirDrop"
   deployment_method  = "Install Automatically"
   level              = "Device Level"
@@ -64,7 +59,7 @@ resource "jamfpro_mobile_device_configuration_profile_plist" "mobile_device_conf
 }
 
 resource "jamfpro_mobile_device_configuration_profile_plist" "mobile_device_configuration_profile_passcode_requirements" {
-  name               = "Passcode Requirements [${random_integer.entropy.result}]"
+  name               = "Passcode Requirements ${var.entropy_string}"
   description        = "Enforces a non complex 6 digit passcode"
   deployment_method  = "Install Automatically"
   level              = "Device Level"
@@ -78,7 +73,7 @@ resource "jamfpro_mobile_device_configuration_profile_plist" "mobile_device_conf
 }
 
 resource "jamfpro_mobile_device_configuration_profile_plist" "mobile_device_configuration_profile_restrict_erase_all_content_and_settings" {
-  name               = "Restrict Erase All Content and Settings [${random_integer.entropy.result}]"
+  name               = "Restrict Erase All Content and Settings ${var.entropy_string}"
   description        = "Restricts Erase All Content and Settings"
   deployment_method  = "Install Automatically"
   level              = "Device Level"
@@ -92,7 +87,7 @@ resource "jamfpro_mobile_device_configuration_profile_plist" "mobile_device_conf
 }
 
 resource "jamfpro_mobile_device_configuration_profile_plist" "mobile_device_configuration_profile_restrict_camera" {
-  name               = "Restrict Camera [${random_integer.entropy.result}]"
+  name               = "Restrict Camera ${var.entropy_string}"
   description        = "Restricts the Camera in all Use and Apps"
   deployment_method  = "Install Automatically"
   level              = "Device Level"
@@ -106,7 +101,7 @@ resource "jamfpro_mobile_device_configuration_profile_plist" "mobile_device_conf
 }
 
 resource "jamfpro_mobile_device_configuration_profile_plist" "mobile_device_configuration_profile_restrict_screenshots" {
-  name               = "Restrict Screenshots [${random_integer.entropy.result}]"
+  name               = "Restrict Screenshots ${var.entropy_string}"
   description        = "Restricts the Ability to take Screenshots"
   deployment_method  = "Install Automatically"
   level              = "Device Level"
@@ -120,7 +115,7 @@ resource "jamfpro_mobile_device_configuration_profile_plist" "mobile_device_conf
 }
 
 resource "jamfpro_mobile_device_configuration_profile_plist" "mobile_device_configuration_profile_user_enrollment_byod_restrictions" {
-  name               = "Demo - User Enrollment / BYOD Restrictions [${random_integer.entropy.result}]"
+  name               = "Demo - User Enrollment / BYOD Restrictions ${var.entropy_string}"
   description        = "Sets DLP restrictions for User Enrollment / BYOD"
   deployment_method  = "Install Automatically"
   level              = "Device Level"
@@ -136,7 +131,7 @@ resource "jamfpro_mobile_device_configuration_profile_plist" "mobile_device_conf
 ## Extension Attribute for Shared Device and Kiosk Mode examples
 
 resource "jamfpro_mobile_device_extension_attribute" "device_type" {
-  name              = "Device Type [${random_integer.entropy.result}]"
+  name              = "Device Type"
   description       = "Select between kiosk, shared, or none for device types"
   data_type         = "String"
   inventory_display = "User and Location"
@@ -153,7 +148,7 @@ resource "jamfpro_mobile_device_extension_attribute" "device_type" {
 ## Smart Groups for Shared Device and Kiosk Mode
 
 resource "jamfpro_smart_mobile_device_group" "device_type_kiosk_mode" {
-  name = "Demo - Kiosk Devices [${random_integer.entropy.result}]"
+  name = "Demo - Kiosk Devices ${var.entropy_string}"
 
   criteria {
     name        = jamfpro_mobile_device_extension_attribute.device_type.name
@@ -164,7 +159,7 @@ resource "jamfpro_smart_mobile_device_group" "device_type_kiosk_mode" {
 }
 
 resource "jamfpro_smart_mobile_device_group" "device_type_shared_device_mode" {
-  name = "Demo - Shared Devices [${random_integer.entropy.result}]"
+  name = "Demo - Shared Devices ${var.entropy_string}"
 
   criteria {
     name        = jamfpro_mobile_device_extension_attribute.device_type.name
@@ -177,7 +172,7 @@ resource "jamfpro_smart_mobile_device_group" "device_type_shared_device_mode" {
 ## Configuration Profiles for Shared Device and Kiosk Mode
 
 resource "jamfpro_mobile_device_configuration_profile_plist" "mobile_device_configuration_profile_kiosk_mode" {
-  name               = "Demo - Kiosk Mode - Safari (Single App Mode) [${random_integer.entropy.result}]"
+  name               = "Demo - Kiosk Mode - Safari (Single App Mode) ${var.entropy_string}"
   description        = "Places device in Single App Mode for Safari"
   deployment_method  = "Install Automatically"
   level              = "Device Level"
@@ -192,7 +187,7 @@ resource "jamfpro_mobile_device_configuration_profile_plist" "mobile_device_conf
 }
 
 resource "jamfpro_mobile_device_configuration_profile_plist" "mobile_device_configuration_profile_shared_device_mode" {
-  name               = "Demo - Shared Device Mode - Restrictions [${random_integer.entropy.result}]"
+  name               = "Demo - Shared Device Mode - Restrictions ${var.entropy_string}"
   description        = "Restricts AirDrop, Apple Account changes, Screenshots, Erase, and Camera"
   deployment_method  = "Install Automatically"
   level              = "Device Level"

--- a/modules/management-iOS-configuration-profiles/variables.tf
+++ b/modules/management-iOS-configuration-profiles/variables.tf
@@ -25,3 +25,8 @@ variable "jamfpro_client_secret" {
   type        = string
   sensitive   = true
 }
+
+variable "random_string" {
+  type    = string
+  default = ""
+}

--- a/modules/management-iOS-configuration-profiles/variables.tf
+++ b/modules/management-iOS-configuration-profiles/variables.tf
@@ -30,3 +30,8 @@ variable "random_string" {
   type    = string
   default = ""
 }
+
+variable "entropy_string" {
+  type    = string
+  default = ""
+}

--- a/modules/management-macOS-SSOe-Okta/main.tf
+++ b/modules/management-macOS-SSOe-Okta/main.tf
@@ -8,20 +8,15 @@ terraform {
   }
 }
 
-resource "random_integer" "entropy" {
-  min = 10
-  max = 999
-}
-
 ## Create categories
 resource "jamfpro_category" "category_ssoe" {
-  name     = "IdP & SSO [${random_integer.entropy.result}]"
+  name     = "IdP & SSO ${var.entropy_string}"
   priority = 9
 }
 
 ## Create scripts
 resource "jamfpro_script" "script_ssoe-okta" {
-  name            = "SSOe-(Okta) [${random_integer.entropy.result}]"
+  name            = "SSOe-(Okta) ${var.entropy_string}"
   priority        = "AFTER"
   script_contents = file("${path.module}/support_files/computer_scripts/SSOe-(Okta).zsh")
   category_id     = jamfpro_category.category_ssoe.id
@@ -30,7 +25,7 @@ resource "jamfpro_script" "script_ssoe-okta" {
 
 ## Create Smart Computer Groups
 resource "jamfpro_smart_computer_group" "ssoe-okta" {
-  name = "SSOe-(Okta) [${random_integer.entropy.result}]"
+  name = "SSOe-(Okta) ${var.entropy_string}"
   criteria {
     name        = "Operating System Version"
     search_type = "like"
@@ -58,7 +53,7 @@ locals {
 ## Create configuration profiles for SSOe Okta (generic)
 resource "jamfpro_macos_configuration_profile_plist" "ssoe-okta" {
   for_each            = local.ssoe-okta_dict
-  name                = "Single Sign On - ${each.key} [${random_integer.entropy.result}]"
+  name                = "Single Sign On - ${each.key} ${var.entropy_string}"
   distribution_method = "Install Automatically"
   redeploy_on_update  = "Newly Assigned"
   category_id         = jamfpro_category.category_ssoe.id
@@ -76,7 +71,7 @@ resource "jamfpro_macos_configuration_profile_plist" "ssoe-okta" {
 
 ## Create policies
 resource "jamfpro_policy" "policy_ssoe" {
-  name            = "Enable SSOe (Okta) [${random_integer.entropy.result}]"
+  name            = "Enable SSOe (Okta) ${var.entropy_string}"
   enabled         = true
   trigger_checkin = true
   frequency       = "Once per computer"

--- a/modules/management-macOS-SSOe-Okta/variables.tf
+++ b/modules/management-macOS-SSOe-Okta/variables.tf
@@ -32,3 +32,8 @@ variable "random_string" {
   type    = string
   default = ""
 }
+
+variable "entropy_string" {
+  type    = string
+  default = ""
+}

--- a/modules/management-macOS-SSOe-Okta/variables.tf
+++ b/modules/management-macOS-SSOe-Okta/variables.tf
@@ -27,3 +27,8 @@ variable "jamfpro_client_secret" {
   sensitive   = true
   default     = ""
 }
+
+variable "random_string" {
+  type    = string
+  default = ""
+}

--- a/modules/management-macOS-microsoft-365/main.tf
+++ b/modules/management-macOS-microsoft-365/main.tf
@@ -8,21 +8,15 @@ terraform {
   }
 }
 
-resource "random_integer" "entropy" {
-  min = 10
-  max = 999
-}
-
 ## Create Microsoft 365 Category
 resource "jamfpro_category" "category_microsoft_365" {
-  name     = "Microsoft 365 [${random_integer.entropy.result}]"
+  name     = "Microsoft 365 ${var.entropy_string}"
   priority = 9
 }
 
-
 ## Create Microsoft 365 Smart Groups
 resource "jamfpro_smart_computer_group" "group_msft_word" {
-  name = "Auto Update:  Microsoft Word [${random_integer.entropy.result}]"
+  name = "Auto Update:  Microsoft Word ${var.entropy_string}"
   criteria {
     name        = "Application Title"
     search_type = "like"
@@ -33,7 +27,7 @@ resource "jamfpro_smart_computer_group" "group_msft_word" {
 }
 
 resource "jamfpro_smart_computer_group" "group_msft_excel" {
-  name = "Auto Update: Microsoft Excel [${random_integer.entropy.result}]"
+  name = "Auto Update: Microsoft Excel ${var.entropy_string}"
   criteria {
     name        = "Application Title"
     search_type = "like"
@@ -44,7 +38,7 @@ resource "jamfpro_smart_computer_group" "group_msft_excel" {
 }
 
 resource "jamfpro_smart_computer_group" "group_msft_onedrive" {
-  name = "Auto Update: Microsoft OneDrive [${random_integer.entropy.result}]"
+  name = "Auto Update: Microsoft OneDrive ${var.entropy_string}"
   criteria {
     name        = "Application Title"
     search_type = "like"
@@ -55,7 +49,7 @@ resource "jamfpro_smart_computer_group" "group_msft_onedrive" {
 }
 
 resource "jamfpro_smart_computer_group" "group_msft_outlook" {
-  name = "Auto Update: Microsoft Outlook [${random_integer.entropy.result}]"
+  name = "Auto Update: Microsoft Outlook ${var.entropy_string}"
   criteria {
     name        = "Application Title"
     search_type = "like"
@@ -66,7 +60,7 @@ resource "jamfpro_smart_computer_group" "group_msft_outlook" {
 }
 
 resource "jamfpro_smart_computer_group" "group_msft_powerpoint" {
-  name = "Auto Update:  Microsoft PowerPoint [${random_integer.entropy.result}]"
+  name = "Auto Update:  Microsoft PowerPoint ${var.entropy_string}"
   criteria {
     name        = "Application Title"
     search_type = "like"
@@ -77,7 +71,7 @@ resource "jamfpro_smart_computer_group" "group_msft_powerpoint" {
 }
 
 # resource "jamfpro_smart_computer_group" "group_msft_edge" {
-#   name = "Auto Update:  Microsoft Edge [${random_integer.entropy.result}]"
+#   name = "Auto Update:  Microsoft Edge ${var.entropy_string}"
 #   criteria {
 #     name        = "Application Title"
 #     search_type = "like"
@@ -88,7 +82,7 @@ resource "jamfpro_smart_computer_group" "group_msft_powerpoint" {
 # }
 
 resource "jamfpro_smart_computer_group" "group_msft_teams" {
-  name = "Auto Update: Microsoft Teams [${random_integer.entropy.result}]"
+  name = "Auto Update: Microsoft Teams ${var.entropy_string}"
   criteria {
     name        = "Application Title"
     search_type = "like"

--- a/modules/management-macOS-microsoft-365/variables.tf
+++ b/modules/management-macOS-microsoft-365/variables.tf
@@ -20,3 +20,8 @@ variable "jamfpro_client_secret" {
   type        = string
   sensitive   = true
 }
+
+variable "random_string" {
+  type    = string
+  default = ""
+}

--- a/modules/management-macOS-microsoft-365/variables.tf
+++ b/modules/management-macOS-microsoft-365/variables.tf
@@ -25,3 +25,8 @@ variable "random_string" {
   type    = string
   default = ""
 }
+
+variable "entropy_string" {
+  type    = string
+  default = ""
+}

--- a/modules/management-macOS-rosetta/main.tf
+++ b/modules/management-macOS-rosetta/main.tf
@@ -8,20 +8,15 @@ terraform {
   }
 }
 
-resource "random_integer" "entropy" {
-  min = 10
-  max = 999
-}
-
 ## Create Categories
 resource "jamfpro_category" "category_admin_tools" {
-  name     = "Admin Tools [${random_integer.entropy.result}]"
+  name     = "Admin Tools ${var.entropy_string}"
   priority = 9
 }
 
 ## Create Smart Group
 resource "jamfpro_smart_computer_group" "group_apple_silicon" {
-  name = "Apple Silicon Macs [${random_integer.entropy.result}]"
+  name = "Apple Silicon Macs ${var.entropy_string}"
   criteria {
     name        = "Apple Silicon"
     search_type = "is"
@@ -33,7 +28,7 @@ resource "jamfpro_smart_computer_group" "group_apple_silicon" {
 
 ## Create Policy
 resource "jamfpro_policy" "policy_rosetta_2" {
-  name            = "Rosetta 2 Install [${random_integer.entropy.result}]"
+  name            = "Rosetta 2 Install ${var.entropy_string}"
   enabled         = true
   trigger_checkin = true
   frequency       = "Once per computer"

--- a/modules/management-macOS-rosetta/variables.tf
+++ b/modules/management-macOS-rosetta/variables.tf
@@ -20,3 +20,8 @@ variable "jamfpro_client_secret" {
   type        = string
   sensitive   = true
 }
+
+variable "random_string" {
+  type    = string
+  default = ""
+}

--- a/modules/management-macOS-rosetta/variables.tf
+++ b/modules/management-macOS-rosetta/variables.tf
@@ -25,3 +25,8 @@ variable "random_string" {
   type    = string
   default = ""
 }
+
+variable "entropy_string" {
+  type    = string
+  default = ""
+}

--- a/modules/network-security-access-policy/variables.tf
+++ b/modules/network-security-access-policy/variables.tf
@@ -168,3 +168,8 @@ variable "enable_jsc_uemc_output" {
   type    = string
   default = ""
 }
+
+variable "random_string" {
+  type    = string
+  default = ""
+}

--- a/modules/network-security-access-policy/variables.tf
+++ b/modules/network-security-access-policy/variables.tf
@@ -173,3 +173,8 @@ variable "random_string" {
   type    = string
   default = ""
 }
+
+variable "entropy_string" {
+  type    = string
+  default = ""
+}

--- a/modules/network-security-jamf-pro-content-filtering-and-network-threat-defense/variables.tf
+++ b/modules/network-security-jamf-pro-content-filtering-and-network-threat-defense/variables.tf
@@ -102,3 +102,8 @@ variable "enable_jsc_uemc_output" {
   type    = string
   default = ""
 }
+
+variable "random_string" {
+  type    = string
+  default = ""
+}

--- a/modules/network-security-jamf-pro-content-filtering-and-network-threat-defense/variables.tf
+++ b/modules/network-security-jamf-pro-content-filtering-and-network-threat-defense/variables.tf
@@ -107,3 +107,8 @@ variable "random_string" {
   type    = string
   default = ""
 }
+
+variable "entropy_string" {
+  type    = string
+  default = ""
+}

--- a/modules/network-security-jamf-pro-content-filtering/variables.tf
+++ b/modules/network-security-jamf-pro-content-filtering/variables.tf
@@ -102,3 +102,8 @@ variable "enable_jsc_uemc_output" {
   type    = string
   default = ""
 }
+
+variable "random_string" {
+  type    = string
+  default = ""
+}

--- a/modules/network-security-jamf-pro-content-filtering/variables.tf
+++ b/modules/network-security-jamf-pro-content-filtering/variables.tf
@@ -107,3 +107,8 @@ variable "random_string" {
   type    = string
   default = ""
 }
+
+variable "entropy_string" {
+  type    = string
+  default = ""
+}

--- a/modules/network-security-jamf-pro-network-threat-defense/variables.tf
+++ b/modules/network-security-jamf-pro-network-threat-defense/variables.tf
@@ -102,3 +102,8 @@ variable "enable_jsc_uemc_output" {
   type    = string
   default = ""
 }
+
+variable "random_string" {
+  type    = string
+  default = ""
+}

--- a/modules/network-security-jamf-pro-network-threat-defense/variables.tf
+++ b/modules/network-security-jamf-pro-network-threat-defense/variables.tf
@@ -107,3 +107,8 @@ variable "random_string" {
   type    = string
   default = ""
 }
+
+variable "entropy_string" {
+  type    = string
+  default = ""
+}

--- a/modules/network-security-jamf-pro-zero-trust-network-access-and-content-filtering/variables.tf
+++ b/modules/network-security-jamf-pro-zero-trust-network-access-and-content-filtering/variables.tf
@@ -102,3 +102,8 @@ variable "enable_jsc_uemc_output" {
   type    = string
   default = ""
 }
+
+variable "random_string" {
+  type    = string
+  default = ""
+}

--- a/modules/network-security-jamf-pro-zero-trust-network-access-and-content-filtering/variables.tf
+++ b/modules/network-security-jamf-pro-zero-trust-network-access-and-content-filtering/variables.tf
@@ -107,3 +107,8 @@ variable "random_string" {
   type    = string
   default = ""
 }
+
+variable "entropy_string" {
+  type    = string
+  default = ""
+}

--- a/modules/network-security-jamf-pro-zero-trust-network-access-and-network-threat-prevention/variables.tf
+++ b/modules/network-security-jamf-pro-zero-trust-network-access-and-network-threat-prevention/variables.tf
@@ -103,3 +103,8 @@ variable "enable_jsc_uemc_output" {
   type    = string
   default = ""
 }
+
+variable "random_string" {
+  type    = string
+  default = ""
+}

--- a/modules/network-security-jamf-pro-zero-trust-network-access-and-network-threat-prevention/variables.tf
+++ b/modules/network-security-jamf-pro-zero-trust-network-access-and-network-threat-prevention/variables.tf
@@ -108,3 +108,8 @@ variable "random_string" {
   type    = string
   default = ""
 }
+
+variable "entropy_string" {
+  type    = string
+  default = ""
+}

--- a/modules/network-security-jamf-pro-zero-trust-network-access/variables.tf
+++ b/modules/network-security-jamf-pro-zero-trust-network-access/variables.tf
@@ -102,3 +102,8 @@ variable "enable_jsc_uemc_output" {
   type    = string
   default = ""
 }
+
+variable "random_string" {
+  type    = string
+  default = ""
+}

--- a/modules/network-security-jamf-pro-zero-trust-network-access/variables.tf
+++ b/modules/network-security-jamf-pro-zero-trust-network-access/variables.tf
@@ -107,3 +107,8 @@ variable "random_string" {
   type    = string
   default = ""
 }
+
+variable "entropy_string" {
+  type    = string
+  default = ""
+}

--- a/modules/network-security-saastenancy/variables.tf
+++ b/modules/network-security-saastenancy/variables.tf
@@ -93,3 +93,8 @@ variable "random_string" {
   type    = string
   default = ""
 }
+
+variable "entropy_string" {
+  type    = string
+  default = ""
+}

--- a/modules/network-security-saastenancy/variables.tf
+++ b/modules/network-security-saastenancy/variables.tf
@@ -88,3 +88,8 @@ variable "jamfpro_instance_url" {
   type      = string
   sensitive = true
 }
+
+variable "random_string" {
+  type    = string
+  default = ""
+}

--- a/modules/onboarder-all/main.tf
+++ b/modules/onboarder-all/main.tf
@@ -17,6 +17,7 @@ module "onboarder-management-macOS" {
   jamfpro_instance_url  = var.jamfpro_instance_url
   jamfpro_client_id     = var.jamfpro_client_id
   jamfpro_client_secret = var.jamfpro_client_secret
+  entropy_string        = var.entropy_string
   providers = {
     jamfpro.jpro = jamfpro.jpro
   }
@@ -27,6 +28,7 @@ module "onboarder-management-mobile" {
   jamfpro_instance_url  = var.jamfpro_instance_url
   jamfpro_client_id     = var.jamfpro_client_id
   jamfpro_client_secret = var.jamfpro_client_secret
+  entropy_string        = var.entropy_string
   providers = {
     jamfpro.jpro = jamfpro.jpro
   }
@@ -37,6 +39,7 @@ module "compliance-macOS-cis-level-1" {
   jamfpro_instance_url  = var.jamfpro_instance_url
   jamfpro_client_id     = var.jamfpro_client_id
   jamfpro_client_secret = var.jamfpro_client_secret
+  entropy_string        = var.entropy_string
   providers = {
     jamfpro.jpro = jamfpro.jpro
   }
@@ -47,6 +50,7 @@ module "compliance-iOS-cis-level-1" {
   jamfpro_instance_url  = var.jamfpro_instance_url
   jamfpro_client_id     = var.jamfpro_client_id
   jamfpro_client_secret = var.jamfpro_client_secret
+  entropy_string        = var.entropy_string
   providers = {
     jamfpro.jpro = jamfpro.jpro
   }
@@ -57,6 +61,7 @@ module "management-macOS-SSOe-Okta" {
   jamfpro_instance_url  = var.jamfpro_instance_url
   jamfpro_client_id     = var.jamfpro_client_id
   jamfpro_client_secret = var.jamfpro_client_secret
+  entropy_string        = var.entropy_string
   providers = {
     jamfpro.jpro = jamfpro.jpro
   }
@@ -71,6 +76,7 @@ module "configuration-jamf-security-cloud-all-services" {
   jamfpro_client_secret = var.jamfpro_client_secret
   jsc_username          = var.jsc_username
   jsc_password          = var.jsc_password
+  entropy_string        = var.entropy_string
   providers = {
     jamfpro.jpro = jamfpro.jpro
     jsc.jsc      = jsc.jsc
@@ -82,6 +88,7 @@ module "configuration-jamf-security-cloud-block-pages" {
   block_page_logo = var.block_page_logo
   jsc_username    = var.jsc_username
   jsc_password    = var.jsc_password
+  entropy_string  = var.entropy_string
   providers = {
     jsc.jsc = jsc.jsc
   }
@@ -92,6 +99,7 @@ module "endpoint-security-macOS-filevault" {
   jamfpro_instance_url  = var.jamfpro_instance_url
   jamfpro_client_id     = var.jamfpro_client_id
   jamfpro_client_secret = var.jamfpro_client_secret
+  entropy_string        = var.entropy_string
   providers = {
     jamfpro.jpro = jamfpro.jpro
   }

--- a/modules/onboarder-all/variables.tf
+++ b/modules/onboarder-all/variables.tf
@@ -486,3 +486,8 @@ variable "include_crowdstrike" {
   type    = bool
   default = false
 }
+
+variable "random_string" {
+  type    = string
+  default = ""
+}

--- a/modules/onboarder-all/variables.tf
+++ b/modules/onboarder-all/variables.tf
@@ -491,3 +491,8 @@ variable "random_string" {
   type    = string
   default = ""
 }
+
+variable "entropy_string" {
+  type    = string
+  default = ""
+}

--- a/modules/onboarder-app-installers/main.tf
+++ b/modules/onboarder-app-installers/main.tf
@@ -39,6 +39,7 @@ module "management-app-installers" {
   jamfpro_instance_url  = var.jamfpro_instance_url
   jamfpro_client_id     = var.jamfpro_client_id
   jamfpro_client_secret = var.jamfpro_client_secret
+  entropy_string        = var.entropy_string
   providers = {
     jamfpro.jpro = jamfpro.jpro
   }

--- a/modules/onboarder-app-installers/variables.tf
+++ b/modules/onboarder-app-installers/variables.tf
@@ -467,3 +467,8 @@ variable "random_string" {
   type    = string
   default = ""
 }
+
+variable "entropy_string" {
+  type    = string
+  default = ""
+}

--- a/modules/onboarder-app-installers/variables.tf
+++ b/modules/onboarder-app-installers/variables.tf
@@ -462,3 +462,8 @@ variable "include_crowdstrike" {
   type    = bool
   default = false
 }
+
+variable "random_string" {
+  type    = string
+  default = ""
+}

--- a/modules/onboarder-management-macOS/main.tf
+++ b/modules/onboarder-management-macOS/main.tf
@@ -13,6 +13,7 @@ module "configuration-jamf-pro-smart-groups" {
   jamfpro_instance_url  = var.jamfpro_instance_url
   jamfpro_client_id     = var.jamfpro_client_id
   jamfpro_client_secret = var.jamfpro_client_secret
+  entropy_string        = var.entropy_string
   providers = {
     jamfpro.jpro = jamfpro.jpro
   }
@@ -23,6 +24,7 @@ module "configuration-jamf-pro-categories" {
   jamfpro_instance_url  = var.jamfpro_instance_url
   jamfpro_client_id     = var.jamfpro_client_id
   jamfpro_client_secret = var.jamfpro_client_secret
+  entropy_string        = var.entropy_string
   providers = {
     jamfpro.jpro = jamfpro.jpro
   }
@@ -33,6 +35,7 @@ module "configuration-jamf-pro-computer-management-settings" {
   jamfpro_instance_url  = var.jamfpro_instance_url
   jamfpro_client_id     = var.jamfpro_client_id
   jamfpro_client_secret = var.jamfpro_client_secret
+  entropy_string        = var.entropy_string
   providers = {
     jamfpro.jpro = jamfpro.jpro
   }
@@ -43,6 +46,7 @@ module "management-macOS-rosetta" {
   jamfpro_instance_url  = var.jamfpro_instance_url
   jamfpro_client_id     = var.jamfpro_client_id
   jamfpro_client_secret = var.jamfpro_client_secret
+  entropy_string        = var.entropy_string
   providers = {
     jamfpro.jpro = jamfpro.jpro
   }

--- a/modules/onboarder-management-macOS/variables.tf
+++ b/modules/onboarder-management-macOS/variables.tf
@@ -461,3 +461,8 @@ variable "include_crowdstrike" {
   type    = bool
   default = false
 }
+
+variable "random_string" {
+  type    = string
+  default = ""
+}

--- a/modules/onboarder-management-macOS/variables.tf
+++ b/modules/onboarder-management-macOS/variables.tf
@@ -466,3 +466,8 @@ variable "random_string" {
   type    = string
   default = ""
 }
+
+variable "entropy_string" {
+  type    = string
+  default = ""
+}

--- a/modules/onboarder-management-mobile/main.tf
+++ b/modules/onboarder-management-mobile/main.tf
@@ -13,6 +13,7 @@ module "management-iOS-configuration-profiles" {
   jamfpro_instance_url  = var.jamfpro_instance_url
   jamfpro_client_id     = var.jamfpro_client_id
   jamfpro_client_secret = var.jamfpro_client_secret
+  entropy_string        = var.entropy_string
   providers = {
     jamfpro.jpro = jamfpro.jpro
   }

--- a/modules/onboarder-management-mobile/variables.tf
+++ b/modules/onboarder-management-mobile/variables.tf
@@ -461,3 +461,8 @@ variable "include_crowdstrike" {
   type    = bool
   default = false
 }
+
+variable "random_string" {
+  type    = string
+  default = ""
+}

--- a/modules/onboarder-management-mobile/variables.tf
+++ b/modules/onboarder-management-mobile/variables.tf
@@ -466,3 +466,8 @@ variable "random_string" {
   type    = string
   default = ""
 }
+
+variable "entropy_string" {
+  type    = string
+  default = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -518,3 +518,13 @@ variable "access_policies" {
   type    = list(string)
   default = []
 }
+
+variable "random_string_boolean" {
+  type    = bool
+  default = false
+}
+
+variable "random_string" {
+  type    = string
+  default = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -528,3 +528,8 @@ variable "random_string" {
   type    = string
   default = ""
 }
+
+variable "entropy_string" {
+  type    = string
+  default = ""
+}


### PR DESCRIPTION
**_Removal of Random Number Entropy_**

Based on feedback, this is removing the Random Number Entropy at the end of each module name from the default module / Onboarder. 

This functionality is still useful for debugging so those running modules locally can un-comment the block in the root main.tf file to re-enable this feature. 

Known Limitation: Extension Attributes resources do not pass names properly with this new approach so the random number entropy will not work for those resource types even when it is re-enabled locally.

## Type of Change

- [x] Refactor (refactoring code, removing code, changing code structure)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] For module changes - I have included an example in the /examples directory and a README.md in the module root
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated spec.yaml as appropriate
- [x] I have checked `Terraform Init` and `Terraform Fmt`
- [x] I have ran `Terraform Apply` against any active module changes
