### PR TITLE
Reverted Protect Module

### DIFF
--- a/modules/configuration-jamf-pro-jamf-protect/main.tf
+++ b/modules/configuration-jamf-pro-jamf-protect/main.tf
@@ -8,16 +8,23 @@ terraform {
   }
 }
 
-resource "jamfpro_jamf_protect" "settings" {
-  protect_url  = var.jamfprotect_url
-  client_id    = var.jamfprotect_clientid
-  password     = var.jamfprotect_client_password
-  auto_install = true
+# Define a resource to use the local-exec provisioner
+resource "null_resource" "run_script" {
 
-  timeouts {
-    create = "90s"
+  triggers = {
+    jamfpro_instance_url  = var.jamfpro_instance_url
+    jamfpro_client_id     = var.jamfpro_client_id
+    jamfpro_client_secret = var.jamfpro_client_secret
+  }
+  provisioner "local-exec" {
+    command = "${path.module}/protectintegrationcreate.sh ${var.jamfpro_instance_url} ${var.jamfpro_client_id} ${var.jamfpro_client_secret} ${var.jamfprotect_url} ${var.jamfprotect_clientid} ${var.jamfprotect_client_password}"
+    when    = create
   }
 
+  provisioner "local-exec" {
+    command = "${path.module}/protectintegrationdelete.sh ${self.triggers.jamfpro_instance_url} ${self.triggers.jamfpro_client_id} ${self.triggers.jamfpro_client_secret}"
+    when    = destroy
+  }
 }
 
 ## Create Category

--- a/modules/configuration-jamf-pro-jamf-protect/protectintegrationcreate.sh
+++ b/modules/configuration-jamf-pro-jamf-protect/protectintegrationcreate.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+jamfpro_instance_url="$1"
+jamfpro_client_id="$2"
+jamfpro_client_secret="$3"
+jamfprotect_url="$4"
+jamfprotect_clientID="$5"
+jamfprotect_client_password="$6"
+
+response=$(curl --silent --location --request POST "${jamfpro_instance_url}/api/oauth/token" \
+	 	--header "Content-Type: application/x-www-form-urlencoded" \
+		--data-urlencode "client_id=${jamfpro_client_id}" \
+		--data-urlencode "grant_type=client_credentials" \
+		--data-urlencode "client_secret=${jamfpro_client_secret}")
+access_token=$(echo "$response" | awk -F'"' '/"access_token":/ {print $4}')
+
+response=$(curl --silent --location --request POST "${jamfpro_instance_url}/api/v1/jamf-protect/register" \
+	 --header "Authorization: Bearer $access_token" \
+     --header "accept: application/json" \
+     --header "content-type: application/json" \
+     --data '{"protectUrl": "'$jamfprotect_url'","clientId": "'$jamfprotect_clientID'","password": "'$jamfprotect_client_password'"}')

--- a/modules/configuration-jamf-pro-jamf-protect/protectintegrationdelete.sh
+++ b/modules/configuration-jamf-pro-jamf-protect/protectintegrationdelete.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+jamfpro_instance_url="$1"
+jamfpro_client_id="$2"
+jamfpro_client_secret="$3"
+jamfprotect_url="$4"
+jamfprotect_clientID="$5"
+jamfprotect_client_password="$6"
+
+response=$(curl --silent --location --request POST "${jamfpro_instance_url}/api/oauth/token" \
+	 	--header "Content-Type: application/x-www-form-urlencoded" \
+		--data-urlencode "client_id=${jamfpro_client_id}" \
+		--data-urlencode "grant_type=client_credentials" \
+		--data-urlencode "client_secret=${jamfpro_client_secret}")
+access_token=$(echo "$response" | awk -F'"' '/"access_token":/ {print $4}')
+
+response=$(curl --silent --location --request DELETE "${jamfpro_instance_url}/api/v1/jamf-protect" \
+	 --header "Authorization: Bearer $access_token" \
+     --header "accept: application/json" \
+     --header "content-type: application/json")

--- a/modules/configuration-jamf-pro-jamf-protect/variables.tf
+++ b/modules/configuration-jamf-pro-jamf-protect/variables.tf
@@ -12,16 +12,19 @@ variable "jamfpro_client_secret" {
   description = "Jamf Pro Client Secret for authentication."
   type        = string
   sensitive   = true
+  default     = ""
 }
 
 variable "jamfprotect_url" {
   description = "Jamf Protect URL name."
   type        = string
+  default     = ""
 }
 
 variable "jamfprotect_clientid" {
   description = "Jamf Protect Client ID for authentication."
   type        = string
+  default     = ""
 }
 
 variable "jamfprotect_client_password" {
@@ -34,11 +37,6 @@ variable "jamfpro_auth_method" {
   description = "Jamf Pro Auth Method."
   type        = string
   default     = "oauth2" #basic or oauth2
-}
-
-variable "random_string" {
-  type    = string
-  default = ""
 }
 
 variable "entropy_string" {

--- a/modules/onboarder-all/main.tf
+++ b/modules/onboarder-all/main.tf
@@ -83,17 +83,6 @@ module "configuration-jamf-security-cloud-all-services" {
   }
 }
 
-module "configuration-jamf-security-cloud-block-pages" {
-  source          = "../configuration-jamf-security-cloud-block-pages"
-  block_page_logo = var.block_page_logo
-  jsc_username    = var.jsc_username
-  jsc_password    = var.jsc_password
-  entropy_string  = var.entropy_string
-  providers = {
-    jsc.jsc = jsc.jsc
-  }
-}
-
 module "endpoint-security-macOS-filevault" {
   source                = "../endpoint-security-macOS-filevault"
   jamfpro_instance_url  = var.jamfpro_instance_url

--- a/spec.yml
+++ b/spec.yml
@@ -114,16 +114,6 @@ options:
     display_name: Configure Web and Network Security Capabilities
     display_desc: Enables Wireguard ZTNA. Configures Content Filtering, Data and Threat Defense Policies. Creates an Activation Profile for deployment to managed devices. Access Policies will need to be configured in console to fully implement ZTNA capabilities.
 
-  - key: include_jsc_block_pages
-    type: <boolean>
-    presence: optional
-    module_name: module.configuration-jamf-security-cloud-block-pages
-    required_provider: jsc
-    content: Provides customizable block pages for organizational policies
-    category: Security
-    display_name: Enable Customizable Block Pages
-    display_desc: Configures block pages for content filtering. Block pages can be further customized with company/organization branding.
-
   - key: include_filevault
     type: <boolean>
     presence: optional


### PR DESCRIPTION
**_Reverted to old Protect Module_**

Due to a timeout issue on response in the API for the Jamf Protect endpoint, we reverted back to the previous bash scripting method. Once a change is made to the Provider, we'll move to the new method. 

Also, removed Block Pages from Onboarder side of the project as they are not reliable and often don't add much value.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (refactoring code, removing code, changing code structure)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] For module changes - I have included an example in the /examples directory and a README.md in the module root
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated spec.yaml as appropriate
- [x] I have checked `Terraform Init` and `Terraform Fmt`
- [x] I have ran `Terraform Apply` against any active module changes
