### PR TITLE
Hotfix - Protect Variable Fix for Reverted Jamf Protect Module

### DIFF
--- a/modules/configuration-jamf-pro-jamf-protect/protectintegrationcreate.sh
+++ b/modules/configuration-jamf-pro-jamf-protect/protectintegrationcreate.sh
@@ -4,7 +4,7 @@ jamfpro_instance_url="$1"
 jamfpro_client_id="$2"
 jamfpro_client_secret="$3"
 jamfprotect_url="$4"
-jamfprotect_clientID="$5"
+jamfprotect_clientid="$5"
 jamfprotect_client_password="$6"
 
 response=$(curl --silent --location --request POST "${jamfpro_instance_url}/api/oauth/token" \
@@ -18,4 +18,4 @@ response=$(curl --silent --location --request POST "${jamfpro_instance_url}/api/
 	 --header "Authorization: Bearer $access_token" \
      --header "accept: application/json" \
      --header "content-type: application/json" \
-     --data '{"protectUrl": "'$jamfprotect_url'","clientId": "'$jamfprotect_clientID'","password": "'$jamfprotect_client_password'"}')
+     --data '{"protectUrl": "'$jamfprotect_url'","clientId": "'$jamfprotect_clientid'","password": "'$jamfprotect_client_password'"}')

--- a/modules/configuration-jamf-pro-jamf-protect/protectintegrationdelete.sh
+++ b/modules/configuration-jamf-pro-jamf-protect/protectintegrationdelete.sh
@@ -4,7 +4,7 @@ jamfpro_instance_url="$1"
 jamfpro_client_id="$2"
 jamfpro_client_secret="$3"
 jamfprotect_url="$4"
-jamfprotect_clientID="$5"
+jamfprotect_clientid="$5"
 jamfprotect_client_password="$6"
 
 response=$(curl --silent --location --request POST "${jamfpro_instance_url}/api/oauth/token" \


### PR DESCRIPTION
**_Hotfix - Reverted Jamf Protect Module Variable Mismatch Fix_**

Recent Jamf Protect module reversion retained a variable that had been adjusted for the rewritten version of the module that is now on hold. This PR is to fix that variable while we wait for the new provider version to release.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Release to main from staging branch

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] For module changes - I have included an example in the /examples directory and a README.md in the module root
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated spec.yaml as appropriate
- [x] I have checked `Terraform Init` and `Terraform Fmt`
- [x] I have ran `Terraform Apply` against any active module changes
