### PR TITLE
Bug Fix: Removed Mobile JSC Profiles

### DIFF
--- a/modules/configuration-jamf-security-cloud-all-services/main.tf
+++ b/modules/configuration-jamf-security-cloud-all-services/main.tf
@@ -83,39 +83,39 @@ resource "jamfpro_smart_mobile_device_group" "supervised_devices" {
   }
 }
 
-resource "jamfpro_smart_mobile_device_group" "unsupervised_devices" {
-  name = "Unsupervised Mobile Devices ${var.entropy_string}"
+# resource "jamfpro_smart_mobile_device_group" "unsupervised_devices" {
+#   name = "Unsupervised Mobile Devices ${var.entropy_string}"
 
-  criteria {
-    name        = "Supervised"
-    priority    = 0
-    search_type = "is"
-    value       = "Unsupervised"
-  }
-  criteria {
-    name        = "Serial Number"
-    priority    = 1
-    search_type = "like"
-    value       = "111222333444555"
-  }
-}
+#   criteria {
+#     name        = "Supervised"
+#     priority    = 0
+#     search_type = "is"
+#     value       = "Unsupervised"
+#   }
+#   criteria {
+#     name        = "Serial Number"
+#     priority    = 1
+#     search_type = "like"
+#     value       = "111222333444555"
+#   }
+# }
 
-resource "jamfpro_smart_mobile_device_group" "byod" {
-  name = "BYOD Mobile Devices ${var.entropy_string}"
+# resource "jamfpro_smart_mobile_device_group" "byod" {
+#   name = "BYOD Mobile Devices ${var.entropy_string}"
 
-  criteria {
-    name        = "Serial Number"
-    priority    = 0
-    search_type = "like"
-    value       = ""
-  }
-  criteria {
-    name        = "Serial Number"
-    priority    = 1
-    search_type = "like"
-    value       = "111222333444555"
-  }
-}
+#   criteria {
+#     name        = "Serial Number"
+#     priority    = 0
+#     search_type = "like"
+#     value       = ""
+#   }
+#   criteria {
+#     name        = "Serial Number"
+#     priority    = 1
+#     search_type = "like"
+#     value       = "111222333444555"
+#   }
+# }
 
 resource "jamfpro_mobile_device_configuration_profile_plist" "all_services_mobile_supervised" {
   name               = "Jamf Connect ZTNA + Jamf Protect Threat and Content Control - Mobile (Supervised) ${var.entropy_string}"
@@ -135,38 +135,36 @@ resource "jamfpro_mobile_device_configuration_profile_plist" "all_services_mobil
   }
 }
 
-resource "jamfpro_mobile_device_configuration_profile_plist" "all_services_mobile_unsupervised" {
-  name               = "Jamf Connect ZTNA + Jamf Protect Threat and Content Control - Mobile (Unsupervised) ${var.entropy_string}"
-  description        = "This configuration profile contains all the pieces you'll need to deploy and enforce ZTNA, Network Security, and Content Control. We have also created a Smart Group called 'Unsupervised Mobile Devices' and scoped this configuration profile to it. To finalize scoping and get this onto devices, navigate to Smart Computer Groups, click on the 'Unsupervised Mobile Devices' group and remove the serial number criteria with the 111222333444555 serial number."
-  deployment_method  = "Install Automatically"
-  level              = "Device Level"
-  category_id        = jamfpro_category.jsc_all_services_profiles.id
-  redeploy_on_update = "Newly Assigned"
+# resource "jamfpro_mobile_device_configuration_profile_plist" "all_services_mobile_unsupervised" {
+#   name               = "Jamf Connect ZTNA + Jamf Protect Threat and Content Control - Mobile (Unsupervised) ${var.entropy_string}"
+#   description        = "This configuration profile contains all the pieces you'll need to deploy and enforce ZTNA, Network Security, and Content Control. We have also created a Smart Group called 'Unsupervised Mobile Devices' and scoped this configuration profile to it. To finalize scoping and get this onto devices, navigate to Smart Computer Groups, click on the 'Unsupervised Mobile Devices' group and remove the serial number criteria with the 111222333444555 serial number."
+#   deployment_method  = "Install Automatically"
+#   level              = "Device Level"
+#   category_id        = jamfpro_category.jsc_all_services_profiles.id
+#   redeploy_on_update = "Newly Assigned"
 
-  payloads         = jsc_ap.all_services.unsupervisedplist
-  payload_validate = false
+#   payloads         = jsc_ap.all_services.unsupervisedplist
+#   payload_validate = false
 
-  scope {
-    all_mobile_devices      = false
-    all_jss_users           = false
-    mobile_device_group_ids = [jamfpro_smart_mobile_device_group.unsupervised_devices.id]
-  }
-}
+#   scope {
+#     all_mobile_devices = false
+#     all_jss_users      = false
+#   }
+# }
 
-resource "jamfpro_mobile_device_configuration_profile_plist" "all_services_mobile_byod" {
-  name               = "Jamf Connect ZTNA + Jamf Protect Threat and Content Control - Mobile (BYOD) ${var.entropy_string}"
-  description        = "This configuration profile contains all the pieces you'll need to deploy and enforce ZTNA, Network Security, and Content Control. We have also created a Smart Group called 'BYOD Mobile Devices' and scoped this configuration profile to it. To finalize scoping and get this onto devices, navigate to Smart Computer Groups, click on the 'BYOD Mobile Devices' group and remove the serial number criteria with the 111222333444555 serial number."
-  deployment_method  = "Install Automatically"
-  level              = "Device Level"
-  category_id        = jamfpro_category.jsc_all_services_profiles.id
-  redeploy_on_update = "Newly Assigned"
+# resource "jamfpro_mobile_device_configuration_profile_plist" "all_services_mobile_byod" {
+#   name               = "Jamf Connect ZTNA + Jamf Protect Threat and Content Control - Mobile (BYOD) ${var.entropy_string}"
+#   description        = "This configuration profile contains all the pieces you'll need to deploy and enforce ZTNA, Network Security, and Content Control. We have also created a Smart Group called 'BYOD Mobile Devices' and scoped this configuration profile to it. To finalize scoping and get this onto devices, navigate to Smart Computer Groups, click on the 'BYOD Mobile Devices' group and remove the serial number criteria with the 111222333444555 serial number."
+#   deployment_method  = "Install Automatically"
+#   level              = "Device Level"
+#   category_id        = jamfpro_category.jsc_all_services_profiles.id
+#   redeploy_on_update = "Newly Assigned"
 
-  payloads         = jsc_ap.all_services.byodplist
-  payload_validate = false
+#   payloads         = jsc_ap.all_services.byodplist
+#   payload_validate = false
 
-  scope {
-    all_mobile_devices      = false
-    all_jss_users           = false
-    mobile_device_group_ids = [jamfpro_smart_mobile_device_group.byod.id]
-  }
-}
+#   scope {
+#     all_mobile_devices = false
+#     all_jss_users      = false
+#   }
+# }


### PR DESCRIPTION
**_Bug Fix: Removed Mobile JSC Profiles_**

Due to a Provider bug, JSC mobile config profiles have been removed. Those will return when the bug is resolved in the Provider

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] For module changes - I have included an example in the /examples directory and a README.md in the module root
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated spec.yaml as appropriate
- [x] I have checked `Terraform Init` and `Terraform Fmt`
- [x] I have ran `Terraform Apply` against any active module changes
