### PR TITLE
Removed Scoping from Mobile Configuration Profilesremoved scope

### DIFF
--- a/modules/management-iOS-configuration-profiles/main.tf
+++ b/modules/management-iOS-configuration-profiles/main.tf
@@ -181,8 +181,8 @@ resource "jamfpro_mobile_device_configuration_profile_plist" "mobile_device_conf
   payloads           = file("${path.module}/support_files/kiosk_mode_safari_single_app_mode.mobileconfig")
 
   scope {
-    all_mobile_devices      = false
-    mobile_device_group_ids = [jamfpro_smart_mobile_device_group.device_type_kiosk_mode.id]
+    all_mobile_devices = false
+    # mobile_device_group_ids = [jamfpro_smart_mobile_device_group.device_type_kiosk_mode.id]
   }
 }
 
@@ -196,7 +196,7 @@ resource "jamfpro_mobile_device_configuration_profile_plist" "mobile_device_conf
   payloads           = file("${path.module}/support_files/shared_device_restrictions.mobileconfig")
 
   scope {
-    all_mobile_devices      = false
-    mobile_device_group_ids = [jamfpro_smart_mobile_device_group.device_type_shared_device_mode.id]
+    all_mobile_devices = false
+    # mobile_device_group_ids = [jamfpro_smart_mobile_device_group.device_type_shared_device_mode.id]
   }
 }


### PR DESCRIPTION
**_Removed Scoping from Mobile Configuration Profiles_**

Due to issues with Jamf Pro calculating Smart Group membership, we have removed the automatic scoping from the Kiosk and Shared device configuration profiles that are created by the `management-iOS-configuration-profiles` module. To scope these after the module runs, just go in and individually scope the profiles to the Demo - Shared Devices and Demo - Kiosk Devices smart groups. 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] For module changes - I have included an example in the /examples directory and a README.md in the module root
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated spec.yaml as appropriate
- [x] I have checked `Terraform Init` and `Terraform Fmt`
- [x] I have ran `Terraform Apply` against any active module changes