### PR TITLE
Added Required Permissions to Jamf Security Cloud <> Jamf Pro API Roles

### DIFF
--- a/modules/configuration-jamf-security-cloud-jamf-pro/main.tf
+++ b/modules/configuration-jamf-security-cloud-jamf-pro/main.tf
@@ -14,17 +14,50 @@ terraform {
 
 resource "jamfpro_api_role" "jamfpro_api_role_sync" {
   display_name = "JSC API Role Device Sync"
-  privileges   = ["Read Mac Applications", "Read Mobile Devices", "Read Mobile Device Applications", "Read Smart Mobile Device Groups", "Read Static Mobile Device Groups", "Read Computers", "Read Smart Computer Groups", "Read Static Computer Groups"]
+  privileges = [
+    "Read Mac Applications",
+    "Read Mobile Devices",
+    "Read Mobile Device Applications",
+    "Read Smart Mobile Device Groups",
+    "Read Static Mobile Device Groups",
+    "Read Computers",
+    "Read Smart Computer Groups",
+    "Create Static Computer Groups",
+    "Read Static Computer Groups"
+  ]
 }
 
 resource "jamfpro_api_role" "jamfpro_api_role_signalling" {
   display_name = "JSC API Role Signalling"
-  privileges   = ["Update Computer Extension Attributes", "Read Computer Extension Attributes", "Delete Computer Extension Attributes", "Create Computer Extension Attributes", "Read Mobile Device Extension Attributes", "Delete Mobile Device Extension Attributes", "Create Mobile Device Extension Attributes", "Update Mobile Devices", "Update Mobile Device Extension Attributes", "Update Computers", "Update User"]
+  privileges = [
+    "Create Computer Extension Attributes",
+    "Read Computer Extension Attributes",
+    "Update Computer Extension Attributes",
+    "Delete Computer Extension Attributes",
+    "Create Mobile Device Extension Attributes",
+    "Read Mobile Device Extension Attributes",
+    "Update Mobile Device Extension Attributes",
+    "Delete Mobile Device Extension Attributes",
+    "Update Mobile Devices",
+    "Update Computers",
+    "Update User"
+  ]
 }
 
 resource "jamfpro_api_role" "jamfpro_api_role_deploy" {
   display_name = "JSC API Role Deploy"
-  privileges   = ["Create iOS Configuration Profiles", "Create macOS Configuration Profiles"]
+  privileges = [
+    "Create iOS Configuration Profiles",
+    "Read iOS Configuration Profiles",
+    "Update iOS Configuration Profiles",
+    "Create macOS Configuration Profiles",
+    "Read macOS Configuration Profiles",
+    "Update macOS Configuration Profiles",
+    "Update Smart Mobile Device Groups",
+    "Update Static Mobile Device Groups",
+    "Update Smart Computer Groups",
+    "Update Static Computer Groups"
+  ]
 }
 
 resource "jamfpro_api_integration" "jamfpro_api_integration_jsc" {


### PR DESCRIPTION
**_Added Required API Permissions_**

This update adds required API permissions to allow for the Deploy to Jamf Pro button to work as outlined [here](https://learn.jamf.com/en-US/bundle/jamf-security-cloud-setup-guide/page/UEM_JamfPro_Establishing_UEM_Connectivity.html). 

You'll now be able to access all functionality enabled by setting up UEM Connect with Jamf Pro.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] For module changes - I have included an example in the /examples directory and a README.md in the module root
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated spec.yaml as appropriate
- [x] I have checked `Terraform Init` and `Terraform Fmt`
- [x] I have ran `Terraform Apply` against any active module changes
