### PR TITLE
ft: SentinelOne

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,29 @@ This repo uses boolean "include_..." variables to turn modules on/off. Most modu
   terraform destroy
   ```
 
+## Tools
+
+Shared utilities live in the [`tools/`](tools/) directory at the repo root. These are invoked automatically by modules at apply time and can also be run manually for inspection or debugging.
+
+### `tools/get_pkg_version.py`
+
+Extracts the application name and version from any macOS `.pkg` file (XAR archive format) without relying on the filename or external tools. The script reads the embedded `PackageInfo` and `Distribution` XML inside the package and prints two lines: the application name (spaces replaced with hyphens) and the version string.
+
+```sh
+python3 tools/get_pkg_version.py /path/to/installer.pkg
+```
+
+Example output:
+
+```
+application-name
+1.2.3
+```
+
+This is used by modules that accept a package source (local path or S3 URL) to produce a clean, version-stamped filename before uploading to Jamf Pro — regardless of what the original file was named. The resulting filename follows the pattern `<name>-<version>.pkg`, for example `jamf-1.2.3.pkg`.
+
+Modules reference this script via a relative path (`../../tools/get_pkg_version.py`) so it is shared across all modules rather than duplicated into each one.
+
 ## Contributing
 
 Contributions are welcome - especially new modules, improvements to existing modules, and documentation updates.

--- a/main.tf
+++ b/main.tf
@@ -329,6 +329,22 @@ module "endpoint-security-macOS-crowdstrike" {
   }
 }
 
+module "endpoint-security-macOS-sentinelone" {
+  count                    = var.include_sentinelone == true ? 1 : 0
+  source                   = "./modules/endpoint-security-macOS-sentinelone"
+  jamfpro_instance_url     = var.jamfpro_instance_url
+  jamfpro_client_id        = var.jamfpro_client_id
+  jamfpro_client_secret    = var.jamfpro_client_secret
+  sentinelone_org_token    = var.sentinelone_org_token
+  sentinelone_pkg_filename = var.sentinelone_pkg_filename
+  sentinelone_pkg_path     = var.sentinelone_pkg_path
+  sentinelone_pkg_base64   = var.sentinelone_pkg_base64
+  sentinelone_pkg_url      = var.sentinelone_pkg_url
+  providers = {
+    jamfpro.jpro = jamfpro.jpro
+  }
+}
+
 module "management-macOS-rosetta" {
   count                 = var.include_rosetta == true ? 1 : 0
   source                = "./modules/management-macOS-rosetta"

--- a/main.tf
+++ b/main.tf
@@ -335,11 +335,9 @@ module "endpoint-security-macOS-sentinelone" {
   jamfpro_instance_url     = var.jamfpro_instance_url
   jamfpro_client_id        = var.jamfpro_client_id
   jamfpro_client_secret    = var.jamfpro_client_secret
-  sentinelone_org_token    = var.sentinelone_org_token
-  sentinelone_pkg_filename = var.sentinelone_pkg_filename
-  sentinelone_pkg_path     = var.sentinelone_pkg_path
-  sentinelone_pkg_base64   = var.sentinelone_pkg_base64
-  sentinelone_pkg_url      = var.sentinelone_pkg_url
+  sentinelone_org_token = var.sentinelone_org_token
+  sentinelone_pkg_path  = var.sentinelone_pkg_path
+  sentinelone_pkg_url   = var.sentinelone_pkg_url
   providers = {
     jamfpro.jpro = jamfpro.jpro
   }

--- a/main.tf
+++ b/main.tf
@@ -330,11 +330,11 @@ module "endpoint-security-macOS-crowdstrike" {
 }
 
 module "endpoint-security-macOS-sentinelone" {
-  count                    = var.include_sentinelone == true ? 1 : 0
-  source                   = "./modules/endpoint-security-macOS-sentinelone"
-  jamfpro_instance_url     = var.jamfpro_instance_url
-  jamfpro_client_id        = var.jamfpro_client_id
-  jamfpro_client_secret    = var.jamfpro_client_secret
+  count                 = var.include_sentinelone == true ? 1 : 0
+  source                = "./modules/endpoint-security-macOS-sentinelone"
+  jamfpro_instance_url  = var.jamfpro_instance_url
+  jamfpro_client_id     = var.jamfpro_client_id
+  jamfpro_client_secret = var.jamfpro_client_secret
   sentinelone_org_token = var.sentinelone_org_token
   sentinelone_pkg_path  = var.sentinelone_pkg_path
   sentinelone_pkg_url   = var.sentinelone_pkg_url

--- a/modules/endpoint-security-macOS-sentinelone/README.md
+++ b/modules/endpoint-security-macOS-sentinelone/README.md
@@ -1,0 +1,101 @@
+# SentinelOne Endpoint Protection - macOS Module
+
+This module creates the necessary pieces in Jamf Pro to deploy and manage the SentinelOne agent on macOS devices in your environment.
+
+## Required Variables
+
+### SentinelOne Configuration
+
+```hcl
+sentinelone_org_token = ""  # Organization/site token from the SentinelOne console
+```
+
+You must also provide the package via **one** of the following methods:
+
+```hcl
+# Option 1: Local file path (filename auto-derived via basename)
+sentinelone_pkg_path = "/path/to/Sentinel-Release-25-3-4-8365_macos_v25_3_4_8365.pkg"
+
+# Option 2: Base64-encoded package content (for CI/CD pipelines)
+sentinelone_pkg_base64 = "..." # Package displays as "SentinelOne.pkg" in Jamf Pro
+```
+
+### Optional Variables
+
+```hcl
+sentinelone_pkg_filename = "SentinelOne.pkg"  # Override the display name in Jamf Pro (only needed for base64 mode)
+```
+
+## What This Module Creates
+
+- **Category**: "SentinelOne" for organizing resources
+- **Configuration Profiles**:
+  - SentinelOne - Service Management (Managed Login Items)
+  - SentinelOne - Network Filter Validation (Content Filter)
+  - SentinelOne - Network Monitoring Extension (System Extensions)
+  - SentinelOne - Privacy Control (PPPC / Full Disk Access)
+- **Smart Computer Groups**:
+  - "SentinelOne Target Group" — devices eligible for deployment (OS >= 13.0, scoped by serial number)
+  - "SentinelOne Installed" — devices that have the SentinelOne agent
+  - "SentinelOne NOT Installed" — devices missing the agent but with the Privacy Control profile
+- **Package**: SentinelOne macOS agent installer uploaded to Jamf Pro
+- **Script**: "SentinelOne License and Install" — writes the registration token and runs the installer
+- **Policy**: "Deploy SentinelOne Agent" — caches the package, runs the install script, and triggers inventory update (scoped to the Target Group, runs once per computer)
+
+## Package Source Options
+
+The module supports two methods of providing the SentinelOne installer package:
+
+### Option 1: File Path (recommended for local/manual use)
+
+Provide the full path to the `.pkg` file. The filename in Jamf Pro is automatically derived from the path using `basename()`.
+
+```hcl
+sentinelone_pkg_path = "./support_files/Sentinel-Release-25-3-4-8365_macos_v25_3_4_8365.pkg"
+```
+
+### Option 2: Base64 Content (for CI/CD pipelines)
+
+Provide the package content as a base64-encoded string. The module decodes it and writes it to a local file before uploading. The package displays as "SentinelOne.pkg" in Jamf Pro (or override with `sentinelone_pkg_filename`).
+
+```hcl
+sentinelone_pkg_base64 = "..." # e.g. from a secrets manager or CI artifact
+```
+
+## Obtaining Your Installer Package
+
+1. Sign in to the [SentinelOne Management Console](https://usea1-partners.sentinelone.net)
+2. Go to **Sentinels** > **Packages**
+3. Download the macOS `.pkg` installer for your desired agent version
+4. Provide it via `sentinelone_pkg_path` or encode it with `base64 -i <file>` for `sentinelone_pkg_base64`
+
+## Implementation Notes
+
+### Configuration Profiles
+
+All four configuration profiles are scoped to **All Computers**. These profiles grant system-level permissions (Full Disk Access, System Extensions, Network Filter, Managed Login Items) that the SentinelOne agent requires to function properly.
+
+### Target Group — Scoped Deployment
+
+The deployment policy is scoped to the "SentinelOne Target Group" smart group. By default this group targets devices with:
+- macOS 13.0 or later
+- A specific serial number (placeholder `111222333444555` — update the criteria to match your target devices)
+
+Edit the `jamfpro_smart_computer_group.sentinelone_target` resource to adjust scoping criteria for your environment.
+
+### Deployment Policy
+
+The policy runs **once per computer** at check-in. It caches the SentinelOne `.pkg` to the Jamf Pro Waiting Room, then runs the install script which writes the organization token and executes the installer. An inventory update (recon) runs after installation to immediately update the device's application inventory.
+
+## References
+
+- [SentinelOne macOS Agent Requirements](https://support.sentinelone.com)
+- [Deploying SentinelOne with Jamf Pro](https://support.sentinelone.com)
+- [Jamf Pro Configuration Profiles](https://learn.jamf.com/bundle/jamf-pro-documentation-current/page/Configuration_Profiles.html)
+
+## Support
+
+For issues related to:
+- **Terraform Module**: Open an issue in this repository
+- **SentinelOne**: Contact SentinelOne Support
+- **Jamf Pro**: Contact Jamf Support

--- a/modules/endpoint-security-macOS-sentinelone/README.md
+++ b/modules/endpoint-security-macOS-sentinelone/README.md
@@ -4,8 +4,6 @@ This module creates the necessary pieces in Jamf Pro to deploy and manage the Se
 
 ## Required Variables
 
-### SentinelOne Configuration
-
 ```hcl
 sentinelone_org_token = ""  # Organization/site token from the SentinelOne console
 ```
@@ -13,53 +11,55 @@ sentinelone_org_token = ""  # Organization/site token from the SentinelOne conso
 You must also provide the package via **one** of the following methods:
 
 ```hcl
-# Option 1: Local file path (filename auto-derived via basename)
-sentinelone_pkg_path = "/path/to/Sentinel-Release-25-3-4-8365_macos_v25_3_4_8365.pkg"
+# Option 1: Local file path
+sentinelone_pkg_path = "/path/to/.pkg"
 
-# Option 2: Base64-encoded package content (for CI/CD pipelines)
-sentinelone_pkg_base64 = "..." # Package displays as "SentinelOne.pkg" in Jamf Pro
+# Option 2: S3 HTTPS URL (used by modular_onboarder CI/CD)
+sentinelone_pkg_url = "https://bucket.s3.region.amazonaws.com/custom-files/session-id/file.pkg"
 ```
 
-### Optional Variables
+## Package Naming
 
-```hcl
-sentinelone_pkg_filename = "SentinelOne.pkg"  # Override the display name in Jamf Pro (only needed for base64 mode)
+Regardless of source, the module automatically extracts the application name and version from the `.pkg`'s embedded XAR metadata and names the package accordingly in Jamf Pro:
+
 ```
+sentinel-agent-25.3.4.8365.pkg
+```
+
+This is derived from the `PackageInfo` or `Distribution` XML inside the package — the original uploaded filename is ignored entirely. The script that performs this extraction lives at [`tools/get_pkg_version.py`](../../tools/get_pkg_version.py) in the repository root and is shared across modules.
 
 ## What This Module Creates
 
-- **Category**: "SentinelOne" for organizing resources
+- **Category**: `SentinelOne`
 - **Configuration Profiles**:
   - SentinelOne - Service Management (Managed Login Items)
   - SentinelOne - Network Filter Validation (Content Filter)
   - SentinelOne - Network Monitoring Extension (System Extensions)
   - SentinelOne - Privacy Control (PPPC / Full Disk Access)
 - **Smart Computer Groups**:
-  - "SentinelOne Target Group" — devices eligible for deployment (OS >= 13.0, scoped by serial number)
-  - "SentinelOne Installed" — devices that have the SentinelOne agent
-  - "SentinelOne NOT Installed" — devices missing the agent but with the Privacy Control profile
-- **Package**: SentinelOne macOS agent installer uploaded to Jamf Pro
-- **Script**: "SentinelOne License and Install" — writes the registration token and runs the installer
-- **Policy**: "Deploy SentinelOne Agent" — caches the package, runs the install script, and triggers inventory update (scoped to the Target Group, runs once per computer)
+  - `SentinelOne Target Group` — devices eligible for deployment (macOS >= 13.0, scoped to a placeholder serial number)
+  - `SentinelOne Installed` — devices with the SentinelOne agent present
+  - `SentinelOne NOT Installed` — devices missing the agent but with the Privacy Control profile applied
+- **Package**: SentinelOne macOS agent installer, version-stamped and uploaded to Jamf Pro
+- **Script**: `SentinelOne License and Install` — writes the registration token then runs the installer
+- **Policy**: `Deploy SentinelOne Agent` — caches the package, runs the install script, triggers inventory update (scoped to Target Group, once per computer)
 
 ## Package Source Options
 
-The module supports two methods of providing the SentinelOne installer package:
+### Option 1: Local file path
 
-### Option 1: File Path (recommended for local/manual use)
-
-Provide the full path to the `.pkg` file. The filename in Jamf Pro is automatically derived from the path using `basename()`.
+Provide the full path to the `.pkg` file. The module copies it to the working directory, extracts the version, and uploads it to Jamf Pro with a clean versioned name.
 
 ```hcl
-sentinelone_pkg_path = "./support_files/Sentinel-Release-25-3-4-8365_macos_v25_3_4_8365.pkg"
+sentinelone_pkg_path = "/path/to/SentinelOne.pkg"
 ```
 
-### Option 2: Base64 Content (for CI/CD pipelines)
+### Option 2: S3 URL (modular_onboarder / CI/CD)
 
-Provide the package content as a base64-encoded string. The module decodes it and writes it to a local file before uploading. The package displays as "SentinelOne.pkg" in Jamf Pro (or override with `sentinelone_pkg_filename`).
+Provide an S3 HTTPS URL. The module downloads the file at apply time using `aws s3 cp` (requires `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` in the runner environment), extracts the version, and uploads to Jamf Pro.
 
 ```hcl
-sentinelone_pkg_base64 = "..." # e.g. from a secrets manager or CI artifact
+sentinelone_pkg_url = "https://bucket.s3.region.amazonaws.com/custom-files/session-id/file.pkg"
 ```
 
 ## Obtaining Your Installer Package
@@ -67,30 +67,28 @@ sentinelone_pkg_base64 = "..." # e.g. from a secrets manager or CI artifact
 1. Sign in to the [SentinelOne Management Console](https://usea1-partners.sentinelone.net)
 2. Go to **Sentinels** > **Packages**
 3. Download the macOS `.pkg` installer for your desired agent version
-4. Provide it via `sentinelone_pkg_path` or encode it with `base64 -i <file>` for `sentinelone_pkg_base64`
 
 ## Implementation Notes
 
 ### Configuration Profiles
 
-All four configuration profiles are scoped to **All Computers**. These profiles grant system-level permissions (Full Disk Access, System Extensions, Network Filter, Managed Login Items) that the SentinelOne agent requires to function properly.
+All four configuration profiles are scoped to **All Computers**. These profiles grant the system-level permissions (Full Disk Access, System Extensions, Network Filter, Managed Login Items) that the SentinelOne agent requires to function.
 
 ### Target Group — Scoped Deployment
 
-The deployment policy is scoped to the "SentinelOne Target Group" smart group. By default this group targets devices with:
+The deployment policy is scoped to the `SentinelOne Target Group` smart group. By default this group targets devices with:
 - macOS 13.0 or later
-- A specific serial number (placeholder `111222333444555` — update the criteria to match your target devices)
+- Serial number matching placeholder `111222333444555`
 
-Edit the `jamfpro_smart_computer_group.sentinelone_target` resource to adjust scoping criteria for your environment.
+Replace the serial number criterion with your test device before expanding deployment to your fleet.
 
 ### Deployment Policy
 
-The policy runs **once per computer** at check-in. It caches the SentinelOne `.pkg` to the Jamf Pro Waiting Room, then runs the install script which writes the organization token and executes the installer. An inventory update (recon) runs after installation to immediately update the device's application inventory.
+The policy runs **once per computer** at check-in. It caches the SentinelOne `.pkg` to the Jamf Waiting Room, then runs the install script which writes the organization token and executes the installer. An inventory update runs after installation to immediately reflect the device's application inventory.
 
 ## References
 
 - [SentinelOne macOS Agent Requirements](https://support.sentinelone.com)
-- [Deploying SentinelOne with Jamf Pro](https://support.sentinelone.com)
 - [Jamf Pro Configuration Profiles](https://learn.jamf.com/bundle/jamf-pro-documentation-current/page/Configuration_Profiles.html)
 
 ## Support

--- a/modules/endpoint-security-macOS-sentinelone/locals.tf
+++ b/modules/endpoint-security-macOS-sentinelone/locals.tf
@@ -1,0 +1,39 @@
+locals {
+  # Derive the package filename:
+  # - From the path (basename) if provided
+  # - Otherwise fall back to the explicit filename variable (required for base64/url mode)
+  sentinelone_pkg_name = var.sentinelone_pkg_path != "" ? basename(var.sentinelone_pkg_path) : var.sentinelone_pkg_filename
+
+  # Determine the package file source:
+  # 1. If a file path is provided, use it directly
+  # 2. If an S3 HTTPS URL is provided, download it to a local file
+  # 3. If base64 content is provided, decode and write to a local file
+  sentinelone_pkg_source = var.sentinelone_pkg_path != "" ? var.sentinelone_pkg_path : (
+    var.sentinelone_pkg_url != "" ? "${path.module}/support_files/${var.sentinelone_pkg_filename}" : (
+      var.sentinelone_pkg_base64 != "" ? "${path.module}/support_files/${var.sentinelone_pkg_filename}" : ""
+    )
+  )
+}
+
+# Download the .pkg from S3 using the virtual-hosted HTTPS URL.
+# Converts https://bucket.s3.region.amazonaws.com/key → s3://bucket/key
+# Requires AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY in the environment.
+resource "terraform_data" "download_sentinelone_pkg" {
+  count = var.sentinelone_pkg_url != "" && var.sentinelone_pkg_path == "" ? 1 : 0
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      BUCKET=$(echo '${var.sentinelone_pkg_url}' | sed 's|https://\([^.]*\)\.s3\..*|\1|')
+      KEY=$(echo '${var.sentinelone_pkg_url}' | sed 's|https://[^/]*/||')
+      aws s3 cp "s3://$BUCKET/$KEY" '${path.module}/support_files/${var.sentinelone_pkg_filename}'
+    EOT
+  }
+
+  triggers_replace = [var.sentinelone_pkg_url]
+}
+
+resource "local_file" "sentinelone_pkg" {
+  count          = var.sentinelone_pkg_base64 != "" && var.sentinelone_pkg_path == "" && var.sentinelone_pkg_url == "" ? 1 : 0
+  content_base64 = var.sentinelone_pkg_base64
+  filename       = "${path.module}/support_files/${var.sentinelone_pkg_filename}"
+}

--- a/modules/endpoint-security-macOS-sentinelone/locals.tf
+++ b/modules/endpoint-security-macOS-sentinelone/locals.tf
@@ -1,39 +1,56 @@
 locals {
-  # Derive the package filename:
-  # - From the path (basename) if provided
-  # - Otherwise fall back to the explicit filename variable (required for base64/url mode)
-  sentinelone_pkg_name = var.sentinelone_pkg_path != "" ? basename(var.sentinelone_pkg_path) : var.sentinelone_pkg_filename
-
-  # Determine the package file source:
-  # 1. If a file path is provided, use it directly
-  # 2. If an S3 HTTPS URL is provided, download it to a local file
-  # 3. If base64 content is provided, decode and write to a local file
-  sentinelone_pkg_source = var.sentinelone_pkg_path != "" ? var.sentinelone_pkg_path : (
-    var.sentinelone_pkg_url != "" ? "${path.module}/support_files/${var.sentinelone_pkg_filename}" : (
-      var.sentinelone_pkg_base64 != "" ? "${path.module}/support_files/${var.sentinelone_pkg_filename}" : ""
-    )
-  )
+  sentinelone_pkg_name   = trimspace(data.local_file.sentinelone_pkg_name.content)
+  sentinelone_pkg_source = "${path.module}/support_files/${local.sentinelone_pkg_name}"
 }
 
-# Download the .pkg from S3 using the virtual-hosted HTTPS URL.
-# Converts https://bucket.s3.region.amazonaws.com/key → s3://bucket/key
-# Requires AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY in the environment.
-resource "terraform_data" "download_sentinelone_pkg" {
+# Read the versioned filename written by whichever prepare resource ran.
+data "local_file" "sentinelone_pkg_name" {
+  filename = "${path.module}/support_files/.pkg_name"
+  depends_on = [
+    terraform_data.prepare_pkg_from_url,
+    terraform_data.prepare_pkg_from_path,
+  ]
+}
+
+# Source: S3 URL — download then extract version.
+resource "terraform_data" "prepare_pkg_from_url" {
   count = var.sentinelone_pkg_url != "" && var.sentinelone_pkg_path == "" ? 1 : 0
 
   provisioner "local-exec" {
     command = <<-EOT
+      set -e
       BUCKET=$(echo '${var.sentinelone_pkg_url}' | sed 's|https://\([^.]*\)\.s3\..*|\1|')
       KEY=$(echo '${var.sentinelone_pkg_url}' | sed 's|https://[^/]*/||')
-      aws s3 cp "s3://$BUCKET/$KEY" '${path.module}/support_files/${var.sentinelone_pkg_filename}'
+      TMP='${path.module}/support_files/.download.pkg'
+      aws s3 cp "s3://$BUCKET/$KEY" "$TMP"
+      PKG_INFO=$(python3 '${path.module}/../../tools/get_pkg_version.py' "$TMP")
+      PKG_NAME=$(echo "$PKG_INFO" | sed -n '1p')
+      PKG_VERSION=$(echo "$PKG_INFO" | sed -n '2p')
+      DEST="$PKG_NAME-$PKG_VERSION.pkg"
+      mv "$TMP" '${path.module}/support_files/'"$DEST"
+      echo -n "$DEST" > '${path.module}/support_files/.pkg_name'
     EOT
   }
 
   triggers_replace = [var.sentinelone_pkg_url]
 }
 
-resource "local_file" "sentinelone_pkg" {
-  count          = var.sentinelone_pkg_base64 != "" && var.sentinelone_pkg_path == "" && var.sentinelone_pkg_url == "" ? 1 : 0
-  content_base64 = var.sentinelone_pkg_base64
-  filename       = "${path.module}/support_files/${var.sentinelone_pkg_filename}"
+# Source: local file path — copy to support_files then extract version.
+resource "terraform_data" "prepare_pkg_from_path" {
+  count = var.sentinelone_pkg_path != "" ? 1 : 0
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      set -e
+      PKG_INFO=$(python3 '${path.module}/../../tools/get_pkg_version.py' '${var.sentinelone_pkg_path}')
+      PKG_NAME=$(echo "$PKG_INFO" | sed -n '1p')
+      PKG_VERSION=$(echo "$PKG_INFO" | sed -n '2p')
+      DEST="$PKG_NAME-$PKG_VERSION.pkg"
+      cp '${var.sentinelone_pkg_path}' '${path.module}/support_files/'"$DEST"
+      echo -n "$DEST" > '${path.module}/support_files/.pkg_name'
+    EOT
+  }
+
+  triggers_replace = [var.sentinelone_pkg_path]
 }
+

--- a/modules/endpoint-security-macOS-sentinelone/locals.tf
+++ b/modules/endpoint-security-macOS-sentinelone/locals.tf
@@ -1,8 +1,3 @@
-locals {
-  sentinelone_pkg_name   = trimspace(data.local_file.sentinelone_pkg_name.content)
-  sentinelone_pkg_source = "${path.module}/support_files/${local.sentinelone_pkg_name}"
-}
-
 # Read the versioned filename written by whichever prepare resource ran.
 data "local_file" "sentinelone_pkg_name" {
   filename = "${path.module}/support_files/.pkg_name"
@@ -10,6 +5,11 @@ data "local_file" "sentinelone_pkg_name" {
     terraform_data.prepare_pkg_from_url,
     terraform_data.prepare_pkg_from_path,
   ]
+}
+
+locals {
+  sentinelone_pkg_name   = trimspace(data.local_file.sentinelone_pkg_name.content)
+  sentinelone_pkg_source = "${path.module}/support_files/${local.sentinelone_pkg_name}"
 }
 
 # Source: S3 URL — download then extract version.

--- a/modules/endpoint-security-macOS-sentinelone/main.tf
+++ b/modules/endpoint-security-macOS-sentinelone/main.tf
@@ -179,7 +179,7 @@ resource "jamfpro_script" "sentinelone_install" {
   os_requirements = ""
   priority        = "AFTER"
   info            = "This script will install and license SentinelOne silently."
-  notes           = "Managed by Terraform. Token is passed via policy parameter 4."
+  notes           = "Token is passed via policy parameter 4."
   parameter4      = "SentinelOne Organization Token"
   parameter5      = "SentinelOne Package Filename"
 }

--- a/modules/endpoint-security-macOS-sentinelone/main.tf
+++ b/modules/endpoint-security-macOS-sentinelone/main.tf
@@ -1,0 +1,233 @@
+## Call Terraform provider
+terraform {
+  required_providers {
+    jamfpro = {
+      source                = "deploymenttheory/jamfpro"
+      configuration_aliases = [jamfpro.jpro]
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.0"
+    }
+  }
+}
+
+## Create Categories
+resource "jamfpro_category" "sentinelone" {
+  name     = "SentinelOne"
+  priority = 9
+}
+
+## SentinelOne Configuration Profiles
+# Deploys 4 configuration profiles from .mobileconfig files:
+#   1. Service Management    — Managed Login Items
+#   2. Network Filter        — Content Filter / socket filter validation
+#   3. Network Extension     — System Extension for network monitoring
+#   4. Privacy Control       — PPPC / Full Disk Access
+
+resource "jamfpro_macos_configuration_profile_plist" "sentinelone_service_management" {
+  name                = "SentinelOne - Service Management"
+  description         = "Prevents removal of SentinelOne Launch Agents and Launch Daemons via Managed Login Items."
+  level               = "System"
+  distribution_method = "Install Automatically"
+  redeploy_on_update  = "Newly Assigned"
+  category_id         = jamfpro_category.sentinelone.id
+  payload_validate    = false
+  user_removable      = false
+
+  payloads = file("${path.module}/support_files/SentinelOne_Service_Management.mobileconfig")
+
+  scope {
+    all_computers = true
+    all_jss_users = false
+  }
+}
+
+resource "jamfpro_macos_configuration_profile_plist" "sentinelone_network_filter" {
+  name                = "SentinelOne - Network Filter Validation"
+  description         = "Authorizes SentinelOne Network Filter automatic validation."
+  level               = "System"
+  distribution_method = "Install Automatically"
+  redeploy_on_update  = "Newly Assigned"
+  category_id         = jamfpro_category.sentinelone.id
+  payload_validate    = false
+  user_removable      = false
+
+  payloads = file("${path.module}/support_files/SentinelOne_Network_Filter_Validation.mobileconfig")
+
+  scope {
+    all_computers = true
+    all_jss_users = false
+  }
+}
+
+resource "jamfpro_macos_configuration_profile_plist" "sentinelone_network_extension" {
+  name                = "SentinelOne - Network Monitoring Extension"
+  description         = "Enables automatic loading of SentinelOne System Extension."
+  level               = "System"
+  distribution_method = "Install Automatically"
+  redeploy_on_update  = "Newly Assigned"
+  category_id         = jamfpro_category.sentinelone.id
+  payload_validate    = false
+  user_removable      = false
+
+  payloads = file("${path.module}/support_files/SentinelOne_Network_Monitoring_Extension.mobileconfig")
+
+  scope {
+    all_computers = true
+    all_jss_users = false
+  }
+}
+
+resource "jamfpro_macos_configuration_profile_plist" "sentinelone_privacy_control" {
+  name                = "SentinelOne - Privacy Control"
+  description         = "Provides Full Disk Access to SentinelOne agent processes."
+  level               = "System"
+  distribution_method = "Install Automatically"
+  redeploy_on_update  = "Newly Assigned"
+  category_id         = jamfpro_category.sentinelone.id
+  payload_validate    = false
+  user_removable      = false
+
+  payloads = file("${path.module}/support_files/SentinelOne_Privacy_Control.mobileconfig")
+
+  scope {
+    all_computers = true
+    all_jss_users = false
+  }
+}
+
+## Smart Computer Groups
+resource "jamfpro_smart_computer_group" "sentinelone_target" {
+  name = "SentinelOne Target Group"
+  criteria {
+    name        = "Operating System Version"
+    search_type = "greater than or equal"
+    value       = "13.0"
+    and_or      = "and"
+    priority    = 0
+  }
+  criteria {
+    name        = "Serial Number"
+    search_type = "like"
+    value       = "111222333444555"
+    and_or      = "and"
+    priority    = 1
+  }
+}
+
+resource "jamfpro_smart_computer_group" "sentinelone_installed" {
+  name = "SentinelOne Installed"
+
+  criteria {
+    name        = "Application Title"
+    priority    = 0
+    search_type = "has"
+    value       = "SentinelOne Extensions.app"
+  }
+}
+
+resource "jamfpro_smart_computer_group" "sentinelone_not_installed" {
+  name = "SentinelOne NOT Installed"
+
+  criteria {
+    name        = "Application Title"
+    priority    = 0
+    and_or      = "and"
+    search_type = "does not have"
+    value       = "SentinelOne Extensions.app"
+  }
+
+  criteria {
+    name        = "Profile Name"
+    priority    = 1
+    and_or      = "and"
+    search_type = "has"
+    value       = "SentinelOne - Privacy Control"
+  }
+}
+
+## SentinelOne Package Upload
+resource "jamfpro_package" "sentinelone_installer" {
+  package_name          = local.sentinelone_pkg_name
+  package_file_source   = local.sentinelone_pkg_source
+  category_id           = jamfpro_category.sentinelone.id
+  info                  = "SentinelOne macOS Agent installer package"
+  notes                 = "Managed by Terraform"
+  priority              = 10
+  reboot_required       = false
+  fill_existing_users   = false
+  fill_user_template    = false
+  os_install            = false
+  suppress_updates      = false
+  suppress_from_dock    = false
+  suppress_eula         = false
+  suppress_registration = false
+
+  timeouts {
+    create = "90m"
+  }
+
+  depends_on = [local_file.sentinelone_pkg, terraform_data.download_sentinelone_pkg]
+}
+
+## SentinelOne Install Script
+resource "jamfpro_script" "sentinelone_install" {
+  name            = "SentinelOne License and Install"
+  script_contents = file("${path.module}/support_files/scripts/sentinelone_install.sh")
+  category_id     = jamfpro_category.sentinelone.id
+  os_requirements = ""
+  priority        = "AFTER"
+  info            = "This script will install and license SentinelOne silently."
+  notes           = "Managed by Terraform. Token is passed via policy parameter 4."
+  parameter4      = "SentinelOne Organization Token"
+  parameter5      = "SentinelOne Package Filename"
+}
+
+## SentinelOne Deployment Policy
+resource "jamfpro_policy" "sentinelone_deploy" {
+  name            = "Deploy SentinelOne Agent"
+  enabled         = true
+  trigger_checkin = true
+  frequency       = "Once per computer"
+  category_id     = jamfpro_category.sentinelone.id
+
+  payloads {
+    packages {
+      distribution_point = "default"
+      package {
+        id                          = jamfpro_package.sentinelone_installer.id
+        action                      = "Cache"
+        fill_user_template          = false
+        fill_existing_user_template = false
+      }
+    }
+
+    scripts {
+      id         = jamfpro_script.sentinelone_install.id
+      priority   = "After"
+      parameter4 = var.sentinelone_org_token
+      parameter5 = local.sentinelone_pkg_name
+    }
+
+    maintenance {
+      recon                       = true
+      reset_name                  = false
+      install_all_cached_packages = false
+      heal                        = false
+      prebindings                 = false
+      permissions                 = false
+      byhost                      = false
+      system_cache                = false
+      user_cache                  = false
+      verify                      = false
+    }
+  }
+
+  scope {
+    all_computers = false
+    all_jss_users = false
+
+    computer_group_ids = [jamfpro_smart_computer_group.sentinelone_target.id]
+  }
+}

--- a/modules/endpoint-security-macOS-sentinelone/main.tf
+++ b/modules/endpoint-security-macOS-sentinelone/main.tf
@@ -6,8 +6,7 @@ terraform {
       configuration_aliases = [jamfpro.jpro]
     }
     local = {
-      source  = "hashicorp/local"
-      version = "~> 2.0"
+      source = "hashicorp/local"
     }
   }
 }
@@ -120,10 +119,10 @@ resource "jamfpro_smart_computer_group" "sentinelone_installed" {
   name = "SentinelOne Installed"
 
   criteria {
-    name        = "Application Title"
+    name        = "Application Bundle ID"
     priority    = 0
     search_type = "has"
-    value       = "SentinelOne Extensions.app"
+    value       = "com.sentinelone.extensions-wrapper"
   }
 }
 
@@ -131,11 +130,11 @@ resource "jamfpro_smart_computer_group" "sentinelone_not_installed" {
   name = "SentinelOne NOT Installed"
 
   criteria {
-    name        = "Application Title"
+    name        = "Application Bundle ID"
     priority    = 0
     and_or      = "and"
     search_type = "does not have"
-    value       = "SentinelOne Extensions.app"
+    value       = "com.sentinelone.extensions-wrapper"
   }
 
   criteria {
@@ -167,8 +166,6 @@ resource "jamfpro_package" "sentinelone_installer" {
   timeouts {
     create = "90m"
   }
-
-  depends_on = [data.local_file.sentinelone_pkg_name]
 }
 
 ## SentinelOne Install Script

--- a/modules/endpoint-security-macOS-sentinelone/main.tf
+++ b/modules/endpoint-security-macOS-sentinelone/main.tf
@@ -121,7 +121,8 @@ resource "jamfpro_smart_computer_group" "sentinelone_installed" {
   criteria {
     name        = "Application Bundle ID"
     priority    = 0
-    search_type = "has"
+    and_or      = "and"
+    search_type = "is"
     value       = "com.sentinelone.extensions-wrapper"
   }
 }
@@ -133,16 +134,8 @@ resource "jamfpro_smart_computer_group" "sentinelone_not_installed" {
     name        = "Application Bundle ID"
     priority    = 0
     and_or      = "and"
-    search_type = "does not have"
+    search_type = "is not"
     value       = "com.sentinelone.extensions-wrapper"
-  }
-
-  criteria {
-    name        = "Profile Name"
-    priority    = 1
-    and_or      = "and"
-    search_type = "has"
-    value       = "SentinelOne - Privacy Control"
   }
 }
 

--- a/modules/endpoint-security-macOS-sentinelone/main.tf
+++ b/modules/endpoint-security-macOS-sentinelone/main.tf
@@ -168,7 +168,7 @@ resource "jamfpro_package" "sentinelone_installer" {
     create = "90m"
   }
 
-  depends_on = [local_file.sentinelone_pkg, terraform_data.download_sentinelone_pkg]
+  depends_on = [data.local_file.sentinelone_pkg_name]
 }
 
 ## SentinelOne Install Script

--- a/modules/endpoint-security-macOS-sentinelone/support_files/SentinelOne_Network_Filter_Validation.mobileconfig
+++ b/modules/endpoint-security-macOS-sentinelone/support_files/SentinelOne_Network_Filter_Validation.mobileconfig
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>FilterDataProviderBundleIdentifier</key>
+			<string>com.sentinelone.network-monitoring</string>
+			<key>FilterDataProviderDesignatedRequirement</key>
+			<string>identifier "com.sentinelone.network-monitoring" and anchor apple generic and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "4AYE5J54KN")</string>
+			<key>FilterGrade</key>
+			<string>firewall</string>
+			<key>FilterPackets</key>
+			<false/>
+			<key>FilterSockets</key>
+			<true/>
+			<key>FilterType</key>
+			<string>Plugin</string>
+			<key>PayloadDisplayName</key>
+			<string>Web Content Filter Payload</string>
+			<key>PayloadIdentifier</key>
+			<string>14DDD990-E2D8-4DD1-8CC6-72FEFB5F252B</string>
+			<key>PayloadOrganization</key>
+			<string>JAMF Software</string>
+			<key>PayloadType</key>
+			<string>com.apple.webcontent-filter</string>
+			<key>PayloadUUID</key>
+			<string>14DDD990-E2D8-4DD1-8CC6-72FEFB5F252B</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>PluginBundleID</key>
+			<string>com.sentinelone.extensions-wrapper</string>
+			<key>UserDefinedName</key>
+			<string>SentinelOne Extensions</string>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>Authorizes SentinelOne Network Filter automatic validation.</string>
+	<key>PayloadDisplayName</key>
+	<string>SentinelOne - Network Filter Validation</string>
+	<key>PayloadIdentifier</key>
+	<string>2C480E0F-AA21-420F-8BC8-0E1AC975BC51</string>
+	<key>PayloadOrganization</key>
+	<string>Sentinel Labs, Inc.</string>
+	<key>PayloadRemovalDisallowed</key>
+	<true/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>2C480E0F-AA21-420F-8BC8-0E1AC975BC51</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/modules/endpoint-security-macOS-sentinelone/support_files/SentinelOne_Network_Monitoring_Extension.mobileconfig
+++ b/modules/endpoint-security-macOS-sentinelone/support_files/SentinelOne_Network_Monitoring_Extension.mobileconfig
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>AllowUserOverrides</key>
+			<true/>
+			<key>AllowedSystemExtensions</key>
+			<dict>
+				<key>4AYE5J54KN</key>
+				<array>
+					<string>com.sentinelone.network-monitoring</string>
+				</array>
+			</dict>
+			<key>PayloadDescription</key>
+			<string></string>
+			<key>PayloadDisplayName</key>
+			<string>System Extensions</string>
+			<key>PayloadIdentifier</key>
+			<string>1BDD5153-6C81-4E0F-B409-1C321FF5E251</string>
+			<key>PayloadOrganization</key>
+			<string>Gete.Net Consulting</string>
+			<key>PayloadType</key>
+			<string>com.apple.system-extension-policy</string>
+			<key>PayloadUUID</key>
+			<string>1BDD5153-6C81-4E0F-B409-1C321FF5E251</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>Enables automatic loading of SentinelOne System Extension.</string>
+	<key>PayloadDisplayName</key>
+	<string>SentinelOne - Network Monitoring Extension</string>
+	<key>PayloadIdentifier</key>
+	<string>67BEF468-52BF-4DC9-96E2-2CCF1FEA127E</string>
+	<key>PayloadOrganization</key>
+	<string>Sentinel Labs, Inc.</string>
+	<key>PayloadRemovalDisallowed</key>
+	<true/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>67BEF468-52BF-4DC9-96E2-2CCF1FEA127E</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/modules/endpoint-security-macOS-sentinelone/support_files/SentinelOne_Privacy_Control.mobileconfig
+++ b/modules/endpoint-security-macOS-sentinelone/support_files/SentinelOne_Privacy_Control.mobileconfig
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDescription</key>
+			<string></string>
+			<key>PayloadDisplayName</key>
+			<string>Privacy Preferences Policy Control</string>
+			<key>PayloadIdentifier</key>
+			<string>236FFBB3-159D-4A5F-B146-AAA7BBA11FF0</string>
+			<key>PayloadOrganization</key>
+			<string>Your Company</string>
+			<key>PayloadType</key>
+			<string>com.apple.TCC.configuration-profile-policy</string>
+			<key>PayloadUUID</key>
+			<string>236FFBB3-159D-4A5F-B146-AAA7BBA11FF0</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>Services</key>
+			<dict>
+				<key>SystemPolicyAllFiles</key>
+				<array>
+					<dict>
+						<key>Allowed</key>
+						<integer>1</integer>
+						<key>CodeRequirement</key>
+						<string>anchor apple generic and identifier "com.sentinelone.sentineld" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "4AYE5J54KN")</string>
+						<key>Identifier</key>
+						<string>com.sentinelone.sentineld</string>
+						<key>IdentifierType</key>
+						<string>bundleID</string>
+						<key>StaticCode</key>
+						<integer>0</integer>
+					</dict>
+					<dict>
+						<key>Allowed</key>
+						<integer>1</integer>
+						<key>CodeRequirement</key>
+						<string>anchor apple generic and identifier "com.sentinelone.sentineld-helper" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "4AYE5J54KN")</string>
+						<key>Identifier</key>
+						<string>com.sentinelone.sentineld-helper</string>
+						<key>IdentifierType</key>
+						<string>bundleID</string>
+						<key>StaticCode</key>
+						<integer>0</integer>
+					</dict>
+					<dict>
+						<key>Allowed</key>
+						<integer>1</integer>
+						<key>CodeRequirement</key>
+						<string>anchor apple generic and identifier "com.sentinelone.sentineld-shell" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "4AYE5J54KN")</string>
+
+						<key>Identifier</key>
+						<string>com.sentinelone.sentineld-shell</string>
+						<key>IdentifierType</key>
+						<string>bundleID</string>
+						<key>StaticCode</key>
+						<integer>0</integer>
+					</dict>
+				</array>
+			</dict>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>Provides access to all disk to Sentinel One processes</string>
+	<key>PayloadDisplayName</key>
+	<string>SentinelOne - Privacy Control</string>
+	<key>PayloadIdentifier</key>
+	<string>5961E10D-A589-4A7E-9790-8F1C55511014</string>
+	<key>PayloadOrganization</key>
+	<string>Sentinel Labs, Inc.</string>
+	<key>PayloadRemovalDisallowed</key>
+	<true/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>5961E10D-A589-4A7E-9790-8F1C55511014</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/modules/endpoint-security-macOS-sentinelone/support_files/SentinelOne_Service_Management.mobileconfig
+++ b/modules/endpoint-security-macOS-sentinelone/support_files/SentinelOne_Service_Management.mobileconfig
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadType</key>
+			<string>com.apple.servicemanagement</string>
+			<key>PayloadIdentifier</key>
+			<string>E01FDD5D-6953-4F89-AE9C-98EC6AF31483</string>
+			<key>PayloadUUID</key>
+			<string>E01FDD5D-6953-4F89-AE9C-98EC6AF31483</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>Rules</key>
+			<array>
+				<dict>
+					<key>RuleType</key>
+					<string>LabelPrefix</string>
+					<key>RuleValue</key>
+					<string>com.sentinelone.</string>
+					<key>Comment</key>
+					<string>Prevent removal of SentinelOne Launch Agents and Launch Daemons</string>
+				</dict>
+				<dict>
+					<key>RuleType</key>
+					<string>BundleIdentifierPrefix</string>
+					<key>RuleValue</key>
+					<string>com.sentinelone.</string>
+					<key>Comment</key>
+					<string>Prevent removal of SentinelOne Launch Agents and Launch Daemons</string>
+				</dict>
+			</array>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>Manage components that run at start up</string>
+	<key>PayloadDisplayName</key>
+	<string>SentinelOne - Service Management</string>
+	<key>PayloadIdentifier</key>
+	<string>8F211DB0-7065-4A0D-8738-7277C7CDD384</string>
+	<key>PayloadOrganization</key>
+	<string>SentinelOne</string>
+	<key>PayloadRemovalDisallowed</key>
+	<true/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>8F211DB0-7065-4A0D-8738-7277C7CDD384</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/modules/endpoint-security-macOS-sentinelone/support_files/scripts/sentinelone_install.sh
+++ b/modules/endpoint-security-macOS-sentinelone/support_files/scripts/sentinelone_install.sh
@@ -1,0 +1,43 @@
+#!/bin/zsh
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SentinelOne License and Install
+# This script installs SentinelOne and registers it with the org token.
+#
+# Parameter 4 ($4): SentinelOne organization token
+# Parameter 5 ($5): SentinelOne installer package filename
+#
+# PDF Reference: Section 1, Steps 9–21
+# ─────────────────────────────────────────────────────────────────────────────
+
+S1_TOKEN="$4"
+S1_PKG_NAME="$5"
+
+# Validate required parameters
+if [[ -z "$S1_TOKEN" ]]; then
+    echo "ERROR: SentinelOne organization token not provided (Parameter 4)"
+    exit 1
+fi
+
+if [[ -z "$S1_PKG_NAME" ]]; then
+    echo "ERROR: SentinelOne package filename not provided (Parameter 5)"
+    exit 1
+fi
+
+WAITING_ROOM="/Library/Application Support/JAMF/Waiting Room"
+
+# Write the registration token
+echo "$S1_TOKEN" > "${WAITING_ROOM}/com.sentinelone.registration-token"
+
+# Install the SentinelOne package
+/usr/sbin/installer -pkg "${WAITING_ROOM}/${S1_PKG_NAME}" -target /
+
+INSTALL_EXIT=$?
+
+if [[ $INSTALL_EXIT -ne 0 ]]; then
+    echo "ERROR: SentinelOne installation failed with exit code $INSTALL_EXIT"
+    exit $INSTALL_EXIT
+fi
+
+echo "SentinelOne installed and licensed successfully."
+exit 0

--- a/modules/endpoint-security-macOS-sentinelone/variables.tf
+++ b/modules/endpoint-security-macOS-sentinelone/variables.tf
@@ -1,0 +1,52 @@
+## Define miscellaneous variables
+variable "jamfpro_instance_url" {
+  description = "Jamf Pro Instance name."
+  type        = string
+}
+
+variable "jamfpro_auth_method" {
+  description = "Jamf Pro Auth Method."
+  type        = string
+  default     = "oauth2" #basic or oauth2
+}
+
+variable "jamfpro_client_id" {
+  description = "Jamf Pro Client ID for authentication."
+  type        = string
+}
+
+variable "jamfpro_client_secret" {
+  description = "Jamf Pro Client Secret for authentication."
+  type        = string
+  sensitive   = true
+}
+
+variable "sentinelone_org_token" {
+  description = "SentinelOne organization/site token used to register the agent"
+  type        = string
+  sensitive   = true
+}
+
+variable "sentinelone_pkg_filename" {
+  description = "Display name for the package in Jamf Pro. Auto-derived from path if using sentinelone_pkg_path."
+  type        = string
+  default     = "SentinelOne.pkg"
+}
+
+variable "sentinelone_pkg_path" {
+  description = "Local file path to the SentinelOne .pkg installer"
+  type        = string
+  default     = ""
+}
+
+variable "sentinelone_pkg_base64" {
+  description = "Base64-encoded SentinelOne .pkg installer content"
+  type        = string
+  default     = ""
+}
+
+variable "sentinelone_pkg_url" {
+  description = "HTTPS URL to the SentinelOne .pkg in S3 (downloaded at apply time via aws s3 cp)"
+  type        = string
+  default     = ""
+}

--- a/modules/endpoint-security-macOS-sentinelone/variables.tf
+++ b/modules/endpoint-security-macOS-sentinelone/variables.tf
@@ -27,20 +27,8 @@ variable "sentinelone_org_token" {
   sensitive   = true
 }
 
-variable "sentinelone_pkg_filename" {
-  description = "Display name for the package in Jamf Pro. Auto-derived from path if using sentinelone_pkg_path."
-  type        = string
-  default     = "SentinelOne.pkg"
-}
-
 variable "sentinelone_pkg_path" {
   description = "Local file path to the SentinelOne .pkg installer"
-  type        = string
-  default     = ""
-}
-
-variable "sentinelone_pkg_base64" {
-  description = "Base64-encoded SentinelOne .pkg installer content"
   type        = string
   default     = ""
 }

--- a/spec.yml
+++ b/spec.yml
@@ -444,14 +444,7 @@ sentinelone:
     presence: optional
     content: Local file path to the SentinelOne .pkg installer
     display_name: SentinelOne Package Path
-    display_desc: "Provide one of: pkg_path (local file), pkg_base64 (base64-encoded content), or pkg_url (S3 HTTPS URL)"
-
-  - key: sentinelone_pkg_base64
-    type: <string>
-    presence: optional
-    content: Base64-encoded SentinelOne .pkg installer content
-    display_name: SentinelOne Package (Base64)
-    display_desc: Base64-encoded content of the SentinelOne .pkg installer
+    display_desc: "Provide one of: pkg_path (local file path) or pkg_url (S3 HTTPS URL)"
 
   - key: sentinelone_pkg_url
     type: <string>
@@ -459,10 +452,3 @@ sentinelone:
     content: HTTPS URL to the SentinelOne .pkg in S3
     display_name: SentinelOne Package S3 URL
     display_desc: Virtual-hosted S3 HTTPS URL — downloaded at apply time via aws s3 cp
-
-  - key: sentinelone_pkg_filename
-    type: <string>
-    presence: optional
-    content: Display name for the package in Jamf Pro (default SentinelOne.pkg)
-    display_name: SentinelOne Package Filename
-    display_desc: Required when using pkg_base64 or pkg_url; auto-derived from pkg_path if that is used

--- a/spec.yml
+++ b/spec.yml
@@ -421,3 +421,48 @@ crowdstrike:
     content: Your CrowdStrike Customer ID without the checksum
     display_name: Falcon Customer ID (CID)
     display_desc: CrowdStrike Customer ID used for Falcon sensor deployment
+
+sentinelone:
+  - key: include_sentinelone
+    type: <boolean>
+    presence: optional
+    module_name: module.endpoint-security-macOS-sentinelone
+    required_provider: jpro
+    category: Security
+    display_name: Deploy SentinelOne Agent
+    display_desc: Configures SentinelOne agent deployment for macOS endpoint protection. Creates the necessary configuration profiles (Service Management, Network Filter, Network Extension, Privacy Control), package upload, install script, smart groups, and deployment policy.
+
+  - key: sentinelone_org_token
+    type: <string>
+    presence: required
+    content: The organization/site token from the SentinelOne console
+    display_name: SentinelOne Organization Token
+    display_desc: Token used to register the SentinelOne agent to your organization
+
+  - key: sentinelone_pkg_path
+    type: <string>
+    presence: optional
+    content: Local file path to the SentinelOne .pkg installer
+    display_name: SentinelOne Package Path
+    display_desc: "Provide one of: pkg_path (local file), pkg_base64 (base64-encoded content), or pkg_url (S3 HTTPS URL)"
+
+  - key: sentinelone_pkg_base64
+    type: <string>
+    presence: optional
+    content: Base64-encoded SentinelOne .pkg installer content
+    display_name: SentinelOne Package (Base64)
+    display_desc: Base64-encoded content of the SentinelOne .pkg installer
+
+  - key: sentinelone_pkg_url
+    type: <string>
+    presence: optional
+    content: HTTPS URL to the SentinelOne .pkg in S3
+    display_name: SentinelOne Package S3 URL
+    display_desc: Virtual-hosted S3 HTTPS URL — downloaded at apply time via aws s3 cp
+
+  - key: sentinelone_pkg_filename
+    type: <string>
+    presence: optional
+    content: Display name for the package in Jamf Pro (default SentinelOne.pkg)
+    display_name: SentinelOne Package Filename
+    display_desc: Required when using pkg_base64 or pkg_url; auto-derived from pkg_path if that is used

--- a/tools/get_pkg_version.py
+++ b/tools/get_pkg_version.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""
+Extract the name and version from a XAR-format .pkg file.
+
+Prints two lines to stdout:
+  <name>
+  <version>
+
+Name resolution order (first non-empty value wins):
+  Distribution: <title> element
+  Distribution: <pkg-ref> CFBundleName attribute
+  PackageInfo:  identifier attribute (last component after the final dot)
+  PackageInfo:  <bundle> CFBundleName attribute
+  fallback:     'unknown'
+
+Version resolution order:
+  PackageInfo:  version attribute
+  Distribution: <pkg-ref> version attribute
+  fallback:     'unknown'
+"""
+import struct, zlib, xml.etree.ElementTree as ET, sys
+
+
+def _read_heap_entry(f, toc_entry, heap_start):
+    d = toc_entry.find('data')
+    if d is None:
+        return None
+    offset = int(d.find('offset').text)
+    length = int(d.find('length').text)
+    f.seek(heap_start + offset)
+    raw = f.read(length)
+    try:
+        raw = zlib.decompress(raw)
+    except Exception:
+        pass
+    return ET.fromstring(raw)
+
+
+def get_pkg_info(path):
+    name = None
+    version = None
+
+    with open(path, 'rb') as f:
+        if f.read(4) != b'xar!':
+            return 'unknown', 'unknown'
+        header_size = struct.unpack('>H', f.read(2))[0]
+        f.read(2)
+        toc_len = struct.unpack('>Q', f.read(8))[0]
+        f.read(12)
+        f.seek(header_size)
+        toc = ET.fromstring(zlib.decompress(f.read(toc_len)))
+        heap_start = header_size + toc_len
+
+        for fe in toc.iter('file'):
+            n = fe.find('name')
+            if n is None:
+                continue
+
+            if n.text == 'Distribution':
+                root = _read_heap_entry(f, fe, heap_start)
+                if root is None:
+                    continue
+                # Title
+                if not name:
+                    t = root.find('title')
+                    if t is not None and t.text and t.text.strip():
+                        name = t.text.strip()
+                # CFBundleName from pkg-ref as fallback name
+                if not name:
+                    for ref in root.iter('pkg-ref'):
+                        n_attr = ref.get('CFBundleName')
+                        if n_attr:
+                            name = n_attr
+                            break
+                # Version from pkg-ref
+                if not version:
+                    for ref in root.iter('pkg-ref'):
+                        v = ref.get('version')
+                        if v:
+                            version = v
+                            break
+
+            elif n.text == 'PackageInfo':
+                root = _read_heap_entry(f, fe, heap_start)
+                if root is None:
+                    continue
+                # Version from PackageInfo attribute (most reliable)
+                if not version:
+                    v = root.get('version')
+                    if v:
+                        version = v
+                # Name from identifier (e.g. com.sentinelone.pkg → sentinelone)
+                if not name:
+                    ident = root.get('identifier', '')
+                    if ident:
+                        name = ident.split('.')[-1]
+                # CFBundleName from nested bundle element
+                if not name:
+                    for b in root.iter('bundle'):
+                        n_attr = b.get('CFBundleName')
+                        if n_attr:
+                            name = n_attr
+                            break
+
+    return name or 'unknown', version or 'unknown'
+
+
+if __name__ == '__main__':
+    pkg_name, pkg_version = get_pkg_info(sys.argv[1])
+    print(pkg_name.replace(' ', '-'))
+    print(pkg_version)

--- a/variables.tf
+++ b/variables.tf
@@ -594,6 +594,42 @@ variable "falcon_customer_id" {
   default     = ""
 }
 
+variable "include_sentinelone" {
+  type    = bool
+  default = false
+}
+
+variable "sentinelone_org_token" {
+  description = "SentinelOne organization/site token used to register the agent"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "sentinelone_pkg_filename" {
+  description = "Display name for the package in Jamf Pro. Auto-derived from path if using sentinelone_pkg_path."
+  type        = string
+  default     = "SentinelOne.pkg"
+}
+
+variable "sentinelone_pkg_path" {
+  description = "Local file path to the SentinelOne .pkg installer"
+  type        = string
+  default     = ""
+}
+
+variable "sentinelone_pkg_base64" {
+  description = "Base64-encoded SentinelOne .pkg installer content"
+  type        = string
+  default     = ""
+}
+
+variable "sentinelone_pkg_url" {
+  description = "HTTPS URL to the SentinelOne .pkg in S3 (downloaded at apply time via aws s3 cp)"
+  type        = string
+  default     = ""
+}
+
 variable "include_onboarder_all" {
   type    = bool
   default = false

--- a/variables.tf
+++ b/variables.tf
@@ -606,20 +606,8 @@ variable "sentinelone_org_token" {
   sensitive   = true
 }
 
-variable "sentinelone_pkg_filename" {
-  description = "Display name for the package in Jamf Pro. Auto-derived from path if using sentinelone_pkg_path."
-  type        = string
-  default     = "SentinelOne.pkg"
-}
-
 variable "sentinelone_pkg_path" {
   description = "Local file path to the SentinelOne .pkg installer"
-  type        = string
-  default     = ""
-}
-
-variable "sentinelone_pkg_base64" {
-  description = "Base64-encoded SentinelOne .pkg installer content"
   type        = string
   default     = ""
 }


### PR DESCRIPTION
# Change

Adds a new `endpoint-security-macOS-sentinelone` module for macOS endpoint protection via the SentinelOne agent.

## SentinelOne module (new)

Creates all Jamf Pro resources required to deploy and manage the SentinelOne agent on macOS:

- **4 configuration profiles**: Service Management (Managed Login Items), Network Filter Validation (Content Filter), Network Monitoring Extension (System Extensions), Privacy Control (PPPC / Full Disk Access)
- **2 smart groups**: `SentinelOne Installed` and `SentinelOne NOT Installed`
- **1 target group**: `SentinelOne Target Group` — scoped to macOS 13.0+, placeholder serial number to limit initial deployment scope
- **Package upload**: SentinelOne macOS agent `.pkg`, version-stamped automatically (see below)
- **Script**: `SentinelOne License and Install` — writes the org token then runs the installer
- **Policy**: `Deploy SentinelOne Agent` — caches package, runs install script, triggers inventory update (once per computer, scoped to Target Group)

Package source is provided via one of two variables:

```hcl
sentinelone_pkg_path = "/path/to/.pkg"       # local file
sentinelone_pkg_url  = "https://bucket.s3…"  # S3 HTTPS URL (CI/CD / modular_onboarder)
```

## Automatic package versioning
Regardless of source, the module extracts the application name and version from the ```.pkg's``` embedded XAR metadata at apply time and names the package accordingly in Jamf Pro (e.g. ```sentinel-agent-25.3.4.8365.pkg```). The original filename is ignored entirely. This extraction is handled by a new shared utility at ```tools/get_pkg_version.py```.

## tools/get_pkg_version.py (new)
Python stdlib-only script that reads ```PackageInfo``` and ```Distribution``` XML from any XAR ```.pkg``` archive and prints the application name and version. Placed at the repo root so it can be shared across future modules. Can also be run manually:

```python3 tools/get_pkg_version.py /path/to/installer.pkg```

##spec.yml
Added sentinelone block with include_sentinelone, sentinelone_org_token, sentinelone_pkg_path, and sentinelone_pkg_url keys for modular_onboarder integration.

## Type of Change
- [X] New feature (non-breaking change which adds functionality)

## Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] For module changes - I have included an example in the /examples directory and a README.md in the module root
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated spec.yaml as appropriate
- [X] I have checked `Terraform Init` and `Terraform Fmt`
- [X] I have ran `Terraform Apply` against any active module changes
