### PR TITLE
fix(sentinelone): CI compatibility and shell portability fixes

### DIFF
--- a/modules/endpoint-security-macOS-sentinelone/locals.tf
+++ b/modules/endpoint-security-macOS-sentinelone/locals.tf
@@ -8,6 +8,7 @@ data "local_file" "sentinelone_pkg_name" {
 }
 
 locals {
+  has_pkg_source         = var.sentinelone_pkg_path != "" || var.sentinelone_pkg_url != ""
   sentinelone_pkg_name   = trimspace(data.local_file.sentinelone_pkg_name.content)
   sentinelone_pkg_source = "${path.module}/support_files/${local.sentinelone_pkg_name}"
 }
@@ -28,7 +29,7 @@ resource "terraform_data" "prepare_pkg_from_url" {
       PKG_VERSION=$(echo "$PKG_INFO" | sed -n '2p')
       DEST="$PKG_NAME-$PKG_VERSION.pkg"
       mv "$TMP" '${path.module}/support_files/'"$DEST"
-      echo -n "$DEST" > '${path.module}/support_files/.pkg_name'
+      printf '%s' "$DEST" > '${path.module}/support_files/.pkg_name'
     EOT
   }
 
@@ -47,7 +48,7 @@ resource "terraform_data" "prepare_pkg_from_path" {
       PKG_VERSION=$(echo "$PKG_INFO" | sed -n '2p')
       DEST="$PKG_NAME-$PKG_VERSION.pkg"
       cp '${var.sentinelone_pkg_path}' '${path.module}/support_files/'"$DEST"
-      echo -n "$DEST" > '${path.module}/support_files/.pkg_name'
+      printf '%s' "$DEST" > '${path.module}/support_files/.pkg_name'
     EOT
   }
 

--- a/modules/endpoint-security-macOS-sentinelone/main.tf
+++ b/modules/endpoint-security-macOS-sentinelone/main.tf
@@ -141,6 +141,7 @@ resource "jamfpro_smart_computer_group" "sentinelone_not_installed" {
 
 ## SentinelOne Package Upload
 resource "jamfpro_package" "sentinelone_installer" {
+  count                 = local.has_pkg_source ? 1 : 0
   package_name          = local.sentinelone_pkg_name
   package_file_source   = local.sentinelone_pkg_source
   category_id           = jamfpro_category.sentinelone.id
@@ -176,6 +177,7 @@ resource "jamfpro_script" "sentinelone_install" {
 
 ## SentinelOne Deployment Policy
 resource "jamfpro_policy" "sentinelone_deploy" {
+  count           = local.has_pkg_source ? 1 : 0
   name            = "Deploy SentinelOne Agent"
   enabled         = true
   trigger_checkin = true
@@ -186,7 +188,7 @@ resource "jamfpro_policy" "sentinelone_deploy" {
     packages {
       distribution_point = "default"
       package {
-        id                          = jamfpro_package.sentinelone_installer.id
+        id                          = jamfpro_package.sentinelone_installer[0].id
         action                      = "Cache"
         fill_user_template          = false
         fill_existing_user_template = false

--- a/modules/endpoint-security-macOS-sentinelone/outputs.tf
+++ b/modules/endpoint-security-macOS-sentinelone/outputs.tf
@@ -1,0 +1,4 @@
+output "deployment_status" {
+  description = "SentinelOne module deployment status"
+  value       = local.has_pkg_source ? "Complete" : "Partial - no package source provided, package upload and deployment policy skipped"
+}

--- a/modules/endpoint-security-macOS-sentinelone/support_files/.pkg_name
+++ b/modules/endpoint-security-macOS-sentinelone/support_files/.pkg_name
@@ -1,0 +1,1 @@
+sentinelone-placeholder.pkg

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,3 +8,8 @@ output "workbrew_client_secret" {
   value       = var.include_workbrew_api_role_client == true ? module.configuration-jamf-pro-api-role-client-workbrew[0].workbrew_client_secret : null
   sensitive   = true
 }
+
+output "sentinelone_deployment_status" {
+  description = "SentinelOne module deployment status"
+  value       = var.include_sentinelone == true ? module.endpoint-security-macOS-sentinelone[0].deployment_status : null
+}


### PR DESCRIPTION
  Fixes CI failure for `include_sentinelone=true` in PR #486.

  The SentinelOne module was failing in CI because `data.local_file` evaluates at plan time, but the `.pkg_name` file it reads is created by
  provisioners at apply time. CI doesn't provide a package source, so the file never existed.

  **Changes:**
  - Add placeholder `.pkg_name` file so `terraform plan` succeeds without a package source
  - Add `count` guards to skip package upload and deployment policy when no source is provided
  - Add `deployment_status` output to surface partial deployment warnings
  - Replace `echo -n` with `printf '%s'` for POSIX shell compatibility (fixes filename containing literal `-n`)

  ## Type of Change

  - [x] Bug fix (non-breaking change which fixes an issue)

  ## Checklist

  - [x] I have checked `Terraform Init` and `Terraform Fmt`
  - [x] I have ran `Terraform Apply` against any active module changes